### PR TITLE
Encode cc-ischedule

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -28,11 +28,10 @@ jobs:
         uses: actions-mn/cache@v1
 
       - name: Metanorma generate site
-        uses: actions-mn/build-and-publish@main
+        uses: actions-mn/build-and-publish@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           agree-to-terms: true
-
+          destination: gh-pages
   deploy:
     if: ${{ github.ref == 'refs/heads/main' }}
     environment:

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = CalConnect Standard: Internet Calendar Scheduling Protocol (iSchedule)
 
-This work item belongs to CalConnect (SCHEDULING TC).
+This work item belongs to CalConnect TC CALENDAR.
 
 image:https://github.com/CalConnect/cc-ischedule/workflows/generate/badge.svg["Build Status", link="https://github.com/CalConnect/cc-ischedule/actions?workflow=generate"]
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,22 +1,21 @@
-= CalConnect Standard: (TITLE)
+= CalConnect Standard: Internet Calendar Scheduling Protocol (iSchedule)
 
-This work item belongs to CalConnect (TCs).
+This work item belongs to CalConnect (SCHEDULING TC).
 
 image:https://github.com/CalConnect/cc-ischedule/workflows/generate/badge.svg["Build Status", link="https://github.com/CalConnect/cc-ischedule/actions?workflow=generate"]
 
 This document is available in its rendered forms here:
 
-* https://calconnect.github.io/cc-ischedule/[CalConnect: Calendaring and scheduling -- Vocabulary (HTML)]
+* https://calconnect.github.io/cc-ischedule/[CalConnect: Internet Calendar Scheduling Protocol (iSchedule) (HTML)]
 
 == General
 
-This document specifies the (TITLE).
+This document specifies the Internet Calendar Scheduling Protocol (iSchedule).
 
 The document is published as the following:
 
-* CalConnect CC (DOCNUMBER)
-* ISO (DOCNUMBER)
-* IETF draft-cc-ischedule
+* CalConnect CC 51010
+* IETF draft-desruisseaux-ischedule
 
 
 == Fetching the document
@@ -62,17 +61,6 @@ The generated documents are accessible under `_site/`.
 metanorma site generate --agree-to-terms
 open _site/index.html
 ----
-
-
-// == IETF: Checking against idnits
-
-// https://tools.ietf.org/tools/idnits/[idnits] is the RFC checking tool prior to
-// submissions.
-
-// [source,sh]
-// ----
-// idnits draft-calconnect-vobject-vformat.nits
-// ----
 
 
 == License

--- a/metanorma.yml
+++ b/metanorma.yml
@@ -2,10 +2,9 @@
 metanorma:
   source:
     files:
-      - sources/cc-51008/document.adoc
-      - sources/ietf/document.adoc
-      - sources/iso-51008/document.adoc
+      - sources/cc-51010.adoc
+      - sources/draft-desruisseaux-ischedule.adoc
 
   collection:
-    name: vObject and vFormat
+    name: Internet Calendar Scheduling Protocol (iSchedule)
     organization: CalConnect

--- a/sources/cc-51010.adoc
+++ b/sources/cc-51010.adoc
@@ -1,0 +1,60 @@
+= Internet Calendar Scheduling Protocol (iSchedule)
+:docnumber: 51010
+:copyright-year: 2017
+:language: en
+:doctype: standard
+:edition: 1
+:status: working-draft
+:revdate: 2017-01-01
+:published-date: 2017-01-01
+:technical-committee: CALENDAR
+:fullname: Cyrus Daboo
+:surname: Daboo
+:givenname: Cyrus
+:affiliation: Apple Inc.
+:fullname_2: Bernard Desruisseaux
+:surname_2: Desruisseaux
+:givenname_2: Bernard
+:affiliation_2: Oracle Corporation
+:fullname_3: Kenneth Murchison
+:surname_3: Murchison
+:givenname_3: Kenneth
+:affiliation_3: Carnegie Mellon University
+:mn-document-class: cc
+:mn-output-extensions: xml,html,pdf,rxl
+:local-cache-only:
+:data-uri-image:
+
+include::sections/00-abstract.adoc[]
+
+include::sections/01-intro.adoc[]
+
+include::sections/01-scope.adoc[]
+
+include::sections/02-normative-references.adoc[]
+
+include::sections/03-terms.adoc[]
+
+include::sections/04-model.adoc[]
+
+include::sections/05-overview.adoc[]
+
+include::sections/06-discovery.adoc[]
+
+include::sections/07-capabilities.adoc[]
+
+include::sections/08-scheduling.adoc[]
+
+include::sections/09-http-headers.adoc[]
+
+include::sections/10-xml-elements.adoc[]
+
+include::sections/11-security.adoc[]
+
+include::sections/12-iana.adoc[]
+
+include::sections/aa-examples.adoc[]
+
+include::sections/99-acknowledgements.adoc[]
+
+include::sections/99-bibliography.adoc[]

--- a/sources/draft-desruisseaux-ischedule.adoc
+++ b/sources/draft-desruisseaux-ischedule.adoc
@@ -1,0 +1,73 @@
+= Internet Calendar Scheduling Protocol (iSchedule)
+:doctype: internet-draft
+:name: draft-desruisseaux-ischedule-06
+:abbrev: iSchedule
+:ipr: trust200902
+:area: Applications
+:updates: IETF RFC 6376
+:intended-series: full-standard
+:published-date: 2017-01-01
+:fullname: Cyrus Daboo
+:lastname: Daboo
+:forename_initials: C.
+:affiliation: Apple Inc.
+:email: cyrus@daboo.name
+:contributor-uri: http://www.apple.com/
+:address: 1 Infinite Loop + \
+Cupertino, CA 95014 + \
+USA
+:fullname_2: Bernard Desruisseaux
+:lastname_2: Desruisseaux
+:forename_initials_2: B.
+:affiliation_2: Oracle Corporation
+:email_2: bernard.desruisseaux@oracle.com
+:contributor-uri_2: http://www.oracle.com/
+:address_2: 600 Blvd. de Maisonneuve West + \
+Suite 1900 + \
+Montreal, QC H3A 3J2 + \
+CANADA
+:fullname_3: Kenneth Murchison
+:lastname_3: Murchison
+:forename_initials_3: K.
+:role_3: editor
+:affiliation_3: Carnegie Mellon University
+:email_3: murch@andrew.cmu.edu
+:contributor-uri_3: http://www.cmu.edu/
+:address_3: 5000 Forbes Avenue + \
+Pittsburgh, PA 15213 + \
+USA
+:keywords: calsched, calsch, caldav, calendar, calendaring, calsify, HTTP, iCal, iCalendar, iMIP, iTIP, iRIP, iSchedule, scheduling, text/calendar
+:mn-document-class: ietf
+:mn-output-extensions: xml,rfc,txt,html,rxl
+:local-cache-only:
+:data-uri-image:
+
+include::sections/00-abstract.adoc[]
+
+include::sections/01-intro.adoc[]
+
+include::sections/04-model.adoc[]
+
+include::sections/05-overview.adoc[]
+
+include::sections/06-discovery.adoc[]
+
+include::sections/07-capabilities.adoc[]
+
+include::sections/08-scheduling.adoc[]
+
+include::sections/09-http-headers.adoc[]
+
+include::sections/10-xml-elements.adoc[]
+
+include::sections/11-security.adoc[]
+
+include::sections/12-iana.adoc[]
+
+include::sections/aa-examples.adoc[]
+
+include::sections/99-acknowledgements.adoc[]
+
+include::sections-ietf/99-references.adoc[]
+
+include::sections-ietf/99-change-history.adoc[]

--- a/sources/draft-desruisseaux-ischedule.adoc
+++ b/sources/draft-desruisseaux-ischedule.adoc
@@ -44,7 +44,7 @@ USA
 
 include::sections/00-abstract.adoc[]
 
-include::sections/01-intro.adoc[]
+include::sections-ietf/01-intro.adoc[]
 
 include::sections/04-model.adoc[]
 

--- a/sources/sections-ietf/01-intro.adoc
+++ b/sources/sections-ietf/01-intro.adoc
@@ -70,3 +70,47 @@ different implementations.
 This document does not attempt to repeat the specification of concepts or
 definitions from these other documents. Where possible, references are made to
 the document that provides the specification of these concepts or definitions.
+
+=== Terminology
+
+This specification reuses much of the same terminology as <<RFC5545,iCalendar>>,
+<<RFC5546,iTIP>>, and <<RFC7230,HTTP>>. Additional terms used by this
+specification are:
+
+Scheduling message:: An <<RFC5545,iCalendar>> object conforming to the
+requirements of <<RFC5546,iTIP>>.
+
+Originator:: The calendar user who is sending a scheduling message to one or
+more other calendar users.
+
+Recipient:: A calendar user to whom a scheduling message is being sent.
+
+iSchedule Sender:: The iSchedule service responsible for sending scheduling
+messages.
+
+iSchedule Receiver:: The iSchedule service responsible for receiving scheduling
+messages.
+
+=== Notational Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in <<RFC2119>>.
+
+The Augmented BNF (ABNF) syntax used by this document to describe protocol
+elements is defined in <<RFC5234>>.
+
+Definitions of XML elements in this document use XML element type declarations
+(as found in XML Document Type Declarations), described in Section 3.2 of
+<<W3C.REC-xml-20081126>>.
+
+The namespace "urn:ietf:params:xml:ns:ischedule" is reserved for the XML
+elements defined in this specification, or in other Standards Track IETF RFCs
+written to extend iSchedule. It MUST NOT be used for proprietary extensions.
+When XML element types in this namespace are referenced in this document outside
+of the context of an XML fragment, the string "IS:" will be prefixed to the
+element type names.
+
+Note that the XML declarations used in this document are incomplete, in that
+they do not include namespace information. Thus, the reader MUST NOT use these
+declarations as the only way to validate iSchedule XML element types.

--- a/sources/sections-ietf/99-change-history.adoc
+++ b/sources/sections-ietf/99-change-history.adoc
@@ -1,0 +1,109 @@
+[appendix]
+== metanorma-extension
+
+=== document history
+
+[EDITOR]
+====
+to be removed by RFC Editor prior to publication
+====
+
+[source,yaml]
+----
+- date:
+  - type: updated
+  edition: 06
+  amend:
+    - description: |
+        Added Ken as editor.
+
+        Updated references.
+
+        Removed DKIM requirement (may be moved to separate document.
+
+        IS:calendar-data element now includes a content-type attribute and the POST response media type must match the one in the request.
+
+        Added IS:rscales to allow receivers to advertise support RSCALE values.
+
+        Updated verification requirements.
+- date:
+  - type: updated
+  edition: 05
+  amend:
+    - description: |
+        Fixed missing Recipient header in example.
+
+        Added statements about what happens when a signature is or is not valid.
+
+        Removed _ischedule SRV record type as we only support HTTPS.
+
+        Removed text about adding an extra Recipient header as we no longer need that.
+- date:
+  - type: updated
+  edition: 04
+  amend:
+    - description: |
+        Added some addition error codes to match MUST requirements.
+
+        Free busy example now shows a failed calendar user response.
+
+        Fixed capabilities response example to add method elements for VTODO and VFREEBUSY.
+
+        More details added to XML element definitions.
+- date:
+  - type: updated
+  edition: 03
+  amend:
+    - description: |
+        Removed http= tag from DKIM header.
+
+        Updated lists of must and must not sign headers.
+
+        Stated that Recipient list must match ATTENDEE list for VFREEBUSY requests.
+
+        Recommend 5 minute skew for t=.
+
+        Added serial-number to capabilities and iSchedule-Capabilities response header.
+
+        Added "ischedule-relaxed" header canonicalization.
+
+        Fixed examples.
+- date:
+  - type: updated
+  edition: 02
+  amend:
+    - description: |
+        Major structural changes as well as addition of new sections, including an Overview.
+
+        Changed capabilities XML schema.
+
+        XML error elements are now named for the actual error as opposed to WebDAV style pre-conditions.
+
+        Removed intermediary support and iSchedule-Via header.
+
+        Added TXT path= lookup to accompany SRV lookup.
+
+        Added http/well-known public key lookup mechanism.
+
+        Added iSchedule-Message-ID header.
+
+        Provided suggested values for t= and x= to cope with clock skew and processing time issues.
+
+        Indicated that iSchedule-Version header can be returned in OPTIONS responses.
+
+        Clarified that Attendee list for VFREEBUSY has to be the same as the Recipient list.
+- date:
+  - type: updated
+  edition: 01
+  amend:
+    - description: |
+        Introduced use of DKIM for calendaring and scheduling services.
+
+        The XML elements "supported-calendar-data" and "calendar-data" were renamed to "supported-calendar-data-type" and "calendar-data-type" respectively to avoid confusion with the "calendar-data" XML element being used in the "response" XML element.
+
+        The "recipient" XML element was redefined to accept (#PCDATA) instead of an "href" XML element.
+
+        The grammar of new HTTP headers is now using the ABNF syntax defined in <<RFC5234>>.
+
+        Fixed various typos.
+----

--- a/sources/sections-ietf/99-references.adoc
+++ b/sources/sections-ietf/99-references.adoc
@@ -1,0 +1,31 @@
+== References
+
+[bibliography]
+=== Normative References
+
+* [[[RFC2119,IETF RFC 2119]]]
+* [[[RFC2782,IETF RFC 2782]]]
+* [[[RFC2818,IETF RFC 2818]]]
+* [[[RFC3688,IETF RFC 3688]]]
+* [[[RFC3986,IETF RFC 3986]]]
+* [[[RFC4033,IETF RFC 4033]]]
+* [[[RFC5234,IETF RFC 5234]]]
+* [[[RFC5246,IETF RFC 5246]]]
+* [[[RFC5545,IETF RFC 5545]]]
+* [[[RFC5546,IETF RFC 5546]]]
+* [[[RFC5785,IETF RFC 5785]]]
+* [[[RFC6763,IETF RFC 6763]]]
+* [[[RFC7230,IETF RFC 7230]]]
+* [[[RFC7232,IETF RFC 7232]]]
+* [[[RFC7234,IETF RFC 7234]]]
+* [[[RFC7235,IETF RFC 7235]]]
+* [[[W3C.REC-xml-20081126,W3C REC-xml-20081126]]], Bray, T., Paoli, J., Sperberg-McQueen, C., Maler, E., and F. Yergeau, "Extensible Markup Language (XML) 1.0 (Fifth Edition)", World Wide Web Consortium Recommendation REC-xml-20081126, November 2008, <http://www.w3.org/TR/2008/REC-xml-20081126>.
+
+[bibliography]
+=== Informative References
+
+* [[[RFC3864,IETF RFC 3864]]]
+* [[[RFC4791,IETF RFC 4791]]]
+* [[[RFC6047,IETF RFC 6047]]]
+* [[[RFC6638,IETF RFC 6638]]]
+* [[[RFC7529,IETF RFC 7529]]]

--- a/sources/sections/00-abstract.adoc
+++ b/sources/sections/00-abstract.adoc
@@ -1,7 +1,7 @@
 [abstract]
 == Abstract
 
-This document defines the Internet Calendar Scheduling Protocol (iSchedule), which is
-a binding from the iCalendar Transport-independent Interoperability Protocol (iTIP) to
-the Hypertext Transfer Protocol (HTTP) to enable interoperability between calendaring
-and scheduling systems over the Internet.
+This document defines the Internet Calendar Scheduling Protocol (iSchedule),
+which is a binding from the iCalendar Transport-independent Interoperability
+Protocol (iTIP) to the Hypertext Transfer Protocol (HTTP) to enable
+interoperability between calendaring and scheduling systems over the Internet.

--- a/sources/sections/00-abstract.adoc
+++ b/sources/sections/00-abstract.adoc
@@ -1,0 +1,7 @@
+[abstract]
+== Abstract
+
+This document defines the Internet Calendar Scheduling Protocol (iSchedule), which is
+a binding from the iCalendar Transport-independent Interoperability Protocol (iTIP) to
+the Hypertext Transfer Protocol (HTTP) to enable interoperability between calendaring
+and scheduling systems over the Internet.

--- a/sources/sections/01-intro.adoc
+++ b/sources/sections/01-intro.adoc
@@ -1,0 +1,107 @@
+[[introduction]]
+== Introduction
+
+This binding document provides the transport specific information necessary to
+convey iCalendar Transport-independent Interoperability Protocol (iTIP) <<RFC5546>>
+messages over the Hypertext Transfer Protocol (HTTP) <<RFC7230>>.
+
+The Internet Calendar Scheduling Protocol (iSchedule) enables interoperability
+between different calendaring and scheduling systems. Calendaring and scheduling
+systems that provide support for iSchedule allow their users to perform scheduling
+transactions such as schedule, reschedule, respond to scheduling request or cancel
+scheduled calendar components, as well as search for busy time information with
+users of other calendaring and scheduling systems on the Internet.
+
+Discussion of this Internet-Draft is taking place on the mailing list
+<https://www.ietf.org/mailman/listinfo/ischedule>.
+
+=== Motivations
+
+The iCalendar Message-Based Interoperability Protocol (iMIP) <<RFC6047>>, has proven
+to be insufficient to allow users to seamlessly perform the same scheduling
+operations with users of other calendaring and scheduling systems on the Internet as
+with users of their own system. This section clarifies the motivations for a binding
+from the iCalendar Transport-independent Interoperability Protocol (iTIP)
+<<RFC5546>> to a transport that allows synchronous end-to-end connectivity.
+
+A binding to an email-based transport is clearly inadequate to search for busy time
+information since users need and expect to get an immediate response. As such, some
+calendaring and scheduling systems allow users to publish their free busy
+information in a resource accessible to others on the Internet. In the absence of a
+standardized mechanism to locate the resource that provides the free busy
+information of a user, one thus needs to know the location of this resource in
+addition to the calendar user address of the users one wishes to schedule with.
+
+With an email-based transport, the transparent processing of incoming scheduling
+messages on the server is only possible when the calendaring and scheduling system
+is integrated with the email system. Commonly, the processing of incoming scheduling
+messages occurs on the client and requires user intervention, which yields the
+following consequences:
+
+. The processing of incoming scheduling messages and the corresponding updates to
+the calendar only occur when the client is active. As a result, free busy
+information may be inaccurate (e.g., user still appears busy when the organizer
+actually rescheduled or canceled the meeting).
+. Calendaring and scheduling systems generally restrain the number of updates sent
+to users to reduce the number of messages that will clutter their email inbox. As a
+result, attendees rarely obtain up to date participation status of other attendees.
+. The client becomes responsible for verification of the authenticity and integrity
+of the scheduling message.
+
+=== Related Memos
+
+Implementers will need to be familiar with other documents that, along with this
+document, form a framework for Internet calendaring and scheduling standards.
+
+This document specifies a binding from iTIP to HTTP.
+
+* <<RFC5545,iCalendar>> specifies a core specification of objects, data types,
+properties and property parameters;
+* <<RFC5546,iTIP>> specifies an interoperability protocol for scheduling between
+different implementations.
+
+This document does not attempt to repeat the specification of concepts or
+definitions from these other documents. Where possible, references are made to the
+document that provides the specification of these concepts or definitions.
+
+=== Terminology
+
+This specification reuses much of the same terminology as <<RFC5545,iCalendar>>,
+<<RFC5546,iTIP>>, and <<RFC7230,HTTP>>. Additional terms used by this specification
+are:
+
+Scheduling message:: An <<RFC5545,iCalendar>> object conforming to the requirements
+of <<RFC5546,iTIP>>.
+
+Originator:: The calendar user who is sending a scheduling message to one or more
+other calendar users.
+
+Recipient:: A calendar user to whom a scheduling message is being sent.
+
+iSchedule Sender:: The iSchedule service responsible for sending scheduling messages.
+
+iSchedule Receiver:: The iSchedule service responsible for receiving scheduling
+messages.
+
+=== Notational Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in <<RFC2119>>.
+
+The Augmented BNF (ABNF) syntax used by this document to describe protocol elements
+is defined in <<RFC5234>>.
+
+Definitions of XML elements in this document use XML element type declarations (as
+found in XML Document Type Declarations), described in Section 3.2 of
+<<W3C.REC-xml-20081126>>.
+
+The namespace "urn:ietf:params:xml:ns:ischedule" is reserved for the XML elements
+defined in this specification, or in other Standards Track IETF RFCs written to
+extend iSchedule. It MUST NOT be used for proprietary extensions. When XML element
+types in this namespace are referenced in this document outside of the context of an
+XML fragment, the string "IS:" will be prefixed to the element type names.
+
+Note that the XML declarations used in this document are incomplete, in that they do
+not include namespace information. Thus, the reader MUST NOT use these declarations
+as the only way to validate iSchedule XML element types.

--- a/sources/sections/01-scope.adoc
+++ b/sources/sections/01-scope.adoc
@@ -1,8 +1,7 @@
 [[scope]]
 == Scope
 
-//This document defines the Internet Calendar Scheduling Protocol (iSchedule), which is a binding from the iCalendar Transport-independent Interoperability Protocol (iTIP) to the Hypertext Transfer Protocol (HTTP) to enable interoperability between calendaring and scheduling systems over the Internet.
-
-//The protocol defined in this document provides a means for calendaring and scheduling systems to perform scheduling operations such as scheduling, rescheduling, responding to scheduling requests, canceling scheduled calendar components, and searching for busy time information with users of other calendaring and scheduling systems on the Internet.
-
-//This document does not define any new calendaring and scheduling functionality beyond what is already defined in the iCalendar Transport-independent Interoperability Protocol (iTIP). Instead, it defines how iTIP messages can be transported over HTTP to enable direct server-to-server communication between different calendaring and scheduling systems.
+This document defines the Internet Calendar Scheduling Protocol (iSchedule),
+which is a binding from the iCalendar Transport-independent Interoperability
+Protocol (iTIP) to the Hypertext Transfer Protocol (HTTP) to enable
+interoperability between calendaring and scheduling systems over the Internet.

--- a/sources/sections/01-scope.adoc
+++ b/sources/sections/01-scope.adoc
@@ -1,0 +1,8 @@
+[[scope]]
+== Scope
+
+//This document defines the Internet Calendar Scheduling Protocol (iSchedule), which is a binding from the iCalendar Transport-independent Interoperability Protocol (iTIP) to the Hypertext Transfer Protocol (HTTP) to enable interoperability between calendaring and scheduling systems over the Internet.
+
+//The protocol defined in this document provides a means for calendaring and scheduling systems to perform scheduling operations such as scheduling, rescheduling, responding to scheduling requests, canceling scheduled calendar components, and searching for busy time information with users of other calendaring and scheduling systems on the Internet.
+
+//This document does not define any new calendaring and scheduling functionality beyond what is already defined in the iCalendar Transport-independent Interoperability Protocol (iTIP). Instead, it defines how iTIP messages can be transported over HTTP to enable direct server-to-server communication between different calendaring and scheduling systems.

--- a/sources/sections/02-normative-references.adoc
+++ b/sources/sections/02-normative-references.adoc
@@ -1,0 +1,20 @@
+[bibliography]
+== Normative References
+
+* [[[RFC2119,IETF RFC 2119]]]
+* [[[RFC2782,IETF RFC 2782]]]
+* [[[RFC2818,IETF RFC 2818]]]
+* [[[RFC3688,IETF RFC 3688]]]
+* [[[RFC3986,IETF RFC 3986]]]
+* [[[RFC4033,IETF RFC 4033]]]
+* [[[RFC5234,IETF RFC 5234]]]
+* [[[RFC5246,IETF RFC 5246]]]
+* [[[RFC5545,IETF RFC 5545]]]
+* [[[RFC5546,IETF RFC 5546]]]
+* [[[RFC5785,IETF RFC 5785]]]
+* [[[RFC6763,IETF RFC 6763]]]
+* [[[RFC7230,IETF RFC 7230]]]
+* [[[RFC7232,IETF RFC 7232]]]
+* [[[RFC7234,IETF RFC 7234]]]
+* [[[RFC7235,IETF RFC 7235]]]
+* [[[W3C.REC-xml-20081126,W3C REC-xml-20081126]]], Bray, T., Paoli, J., Sperberg-McQueen, C., Maler, E., and F. Yergeau, "Extensible Markup Language (XML) 1.0 (Fifth Edition)", World Wide Web Consortium Recommendation REC-xml-20081126, November 2008, <http://www.w3.org/TR/2008/REC-xml-20081126>.

--- a/sources/sections/03-conventions.adoc
+++ b/sources/sections/03-conventions.adoc
@@ -1,0 +1,24 @@
+
+== Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in <<RFC2119>>.
+
+The Augmented BNF (ABNF) syntax used by this document to describe protocol
+elements is defined in <<RFC5234>>.
+
+Definitions of XML elements in this document use XML element type declarations
+(as found in XML Document Type Declarations), described in Section 3.2 of
+<<W3C.REC-xml-20081126>>.
+
+The namespace "urn:ietf:params:xml:ns:ischedule" is reserved for the XML
+elements defined in this specification, or in other Standards Track IETF RFCs
+written to extend iSchedule. It MUST NOT be used for proprietary extensions.
+When XML element types in this namespace are referenced in this document outside
+of the context of an XML fragment, the string "IS:" will be prefixed to the
+element type names.
+
+Note that the XML declarations used in this document are incomplete, in that
+they do not include namespace information. Thus, the reader MUST NOT use these
+declarations as the only way to validate iSchedule XML element types.

--- a/sources/sections/03-terms.adoc
+++ b/sources/sections/03-terms.adoc
@@ -1,2 +1,28 @@
 [[terms]]
-== Terms and Definitions
+== Terms and definitions
+
+This specification reuses much of the same terminology as <<RFC5545,iCalendar>>,
+<<RFC5546,iTIP>>, and <<RFC7230,HTTP>>. Additional terms used by this
+specification are:
+
+=== Scheduling message
+
+An <<RFC5545,iCalendar>> object conforming to the requirements of
+<<RFC5546,iTIP>>.
+
+=== Originator
+
+The calendar user who is sending a scheduling message to one or more other
+calendar users.
+
+=== Recipient
+
+A calendar user to whom a scheduling message is being sent.
+
+=== iSchedule Sender
+
+The iSchedule service responsible for sending scheduling messages.
+
+=== iSchedule Receiver
+
+The iSchedule service responsible for receiving scheduling messages.

--- a/sources/sections/03-terms.adoc
+++ b/sources/sections/03-terms.adoc
@@ -1,0 +1,2 @@
+[[terms]]
+== Terms and Definitions

--- a/sources/sections/04-model.adoc
+++ b/sources/sections/04-model.adoc
@@ -1,0 +1,33 @@
+[[model]]
+== iSchedule Model
+
+The iSchedule design can be pictured as:
+
+[source%unnumbered]
+----
++----------+   +-----------+            +-----------+   +----------+
+| Calendar |   | Calendar  |            | Calendar  |   | Calendar |
+| Store    |   | Service   | iSchedule  | Service   |   | Store    |
+|  or      |-->|===========|----------->|===========|-->|  or      |
+| User     |   | iSchedule |            | iSchedule |   | User     |
+| Agent    |   | Sender    |            | Receiver  |   | Agent    |
++----------+   +-----------+            +-----------+   +----------+
+----
+
+When an iSchedule Sender has a scheduling message to transmit, it determines the
+iSchedule Receivers to which to deliver the message and sends the appropriate
+iSchedule message. The iSchedule Receiver verifies the authenticity and content of
+the iSchedule message and delivers it to the Calendar Service.
+
+The means by which a Calendar Store or User Agent instructs a Calendar Service,
+acting as an iSchedule Sender, to transmit scheduling messages is outside the scope
+of this document. A Calendar Service could provide support for a standard calendar
+access protocol, such as CalDAV <<RFC4791>>, <<RFC6638>> or any other protocol, to
+allow a Calendar User Agent to perform scheduling operations with users of other
+Calendar Services.
+
+Likewise, the actual processing of scheduling messages received by a Calendar
+Service, acting as an iSchedule Receiver, is also outside the scope of this
+document. Some Calendar Service implementations may decide to process some or all
+received scheduling messages, while other implementations may decide to leave that
+work to Calendar User Agent implementations.

--- a/sources/sections/04-model.adoc
+++ b/sources/sections/04-model.adoc
@@ -16,18 +16,18 @@ The iSchedule design can be pictured as:
 
 When an iSchedule Sender has a scheduling message to transmit, it determines the
 iSchedule Receivers to which to deliver the message and sends the appropriate
-iSchedule message. The iSchedule Receiver verifies the authenticity and content of
-the iSchedule message and delivers it to the Calendar Service.
+iSchedule message. The iSchedule Receiver verifies the authenticity and content
+of the iSchedule message and delivers it to the Calendar Service.
 
 The means by which a Calendar Store or User Agent instructs a Calendar Service,
-acting as an iSchedule Sender, to transmit scheduling messages is outside the scope
-of this document. A Calendar Service could provide support for a standard calendar
-access protocol, such as CalDAV <<RFC4791>>, <<RFC6638>> or any other protocol, to
-allow a Calendar User Agent to perform scheduling operations with users of other
-Calendar Services.
+acting as an iSchedule Sender, to transmit scheduling messages is outside the
+scope of this document. A Calendar Service could provide support for a standard
+calendar access protocol, such as CalDAV <<RFC4791>>, <<RFC6638>> or any other
+protocol, to allow a Calendar User Agent to perform scheduling operations with
+users of other Calendar Services.
 
 Likewise, the actual processing of scheduling messages received by a Calendar
 Service, acting as an iSchedule Receiver, is also outside the scope of this
-document. Some Calendar Service implementations may decide to process some or all
-received scheduling messages, while other implementations may decide to leave that
-work to Calendar User Agent implementations.
+document. Some Calendar Service implementations may decide to process some or
+all received scheduling messages, while other implementations may decide to
+leave that work to Calendar User Agent implementations.

--- a/sources/sections/05-overview.adoc
+++ b/sources/sections/05-overview.adoc
@@ -2,15 +2,16 @@
 == iSchedule Overview
 
 This section provides an overview of the various steps involved for iSchedule
-Senders and Receivers to transmit scheduling messages between Calendar Services. It
-references later sections describing the precise details of each step.
+Senders and Receivers to transmit scheduling messages between Calendar Services.
+It references later sections describing the precise details of each step.
 
 === iSchedule Sender Actions
 
 A Calendar Service will generate an iTIP <<RFC5546>> scheduling message for
-transmission. It will additionally provide details of the Originator and Recipients.
-The Calendar Service will "submit" the scheduling message and details to the
-iSchedule Sender, through a process that is outside the scope of this document.
+transmission. It will additionally provide details of the Originator and
+Recipients. The Calendar Service will "submit" the scheduling message and
+details to the iSchedule Sender, through a process that is outside the scope of
+this document.
 
 The iSchedule Sender MUST verify the authenticity of the Originator and the
 Originator's authorization to send the scheduling message. In particular the
@@ -18,41 +19,44 @@ Originator's authorization to send the scheduling message. In particular the
 address. The process by which this authentication and authorization is done is
 outside the scope of this document.
 
-For each Recipient, the iSchedule Sender will attempt to lookup a matching iSchedule
-Receiver to which the iSchedule message can be sent, following the rules in
-<<discovery>>. After determining the iSchedule Receiver to use, the iSchedule Sender
-MUST check the capabilities of the iSchedule Receiver to ensure it will be able to
-accept the scheduling message that needs to be sent, as per <<capabilities>>.
+For each Recipient, the iSchedule Sender will attempt to lookup a matching
+iSchedule Receiver to which the iSchedule message can be sent, following the
+rules in <<discovery>>. After determining the iSchedule Receiver to use, the
+iSchedule Sender MUST check the capabilities of the iSchedule Receiver to ensure
+it will be able to accept the scheduling message that needs to be sent, as per
+<<capabilities>>.
 
-The iSchedule Sender MUST group together Recipients for whom the iSchedule Receiver
-is the same, so that a single scheduling message is sent for multiple Recipients,
-within the limits of the <<max-recipients,IS:max-recipients>> value specified in the
-iSchedule Receiver's capabilities.
+The iSchedule Sender MUST group together Recipients for whom the iSchedule
+Receiver is the same, so that a single scheduling message is sent for multiple
+Recipients, within the limits of the <<max-recipients,IS:max-recipients>> value
+specified in the iSchedule Receiver's capabilities.
 
-For each group of Recipients handled by the same iSchedule Receiver, the iSchedule
-Sender will construct an HTTP request, as per <<scheduling>>, with the body of the
-HTTP request containing the iSchedule message. Note, in the case of a "VFREEBUSY"
-iSchedule message, the iSchedule Sender MUST ensure that iCalendar "ATTENDEE"
-properties in the iSchedule message match one-for-one with the Recipients listed in
-the HTTP request header.
+For each group of Recipients handled by the same iSchedule Receiver, the
+iSchedule Sender will construct an HTTP request, as per <<scheduling>>, with the
+body of the HTTP request containing the iSchedule message. Note, in the case of
+a "VFREEBUSY" iSchedule message, the iSchedule Sender MUST ensure that iCalendar
+"ATTENDEE" properties in the iSchedule message match one-for-one with the
+Recipients listed in the HTTP request header.
 
-The iSchedule Sender then sends the HTTP request to the iSchedule Receiver handling
-the Recipient group, and receives the HTTP response, which will be an XML document
-with either an IS:schedule-response or IS:error element as the root element.
+The iSchedule Sender then sends the HTTP request to the iSchedule Receiver
+handling the Recipient group, and receives the HTTP response, which will be an
+XML document with either an IS:schedule-response or IS:error element as the root
+element.
 
-The iSchedule Sender aggregates the results for each Recipient group receiving an
-iSchedule message, and returns the resulting status information for each Recipient
-to the Calendar Service that generated the schedule message. The process by which
-this is done is outside the scope of this document.
+The iSchedule Sender aggregates the results for each Recipient group receiving
+an iSchedule message, and returns the resulting status information for each
+Recipient to the Calendar Service that generated the schedule message. The
+process by which this is done is outside the scope of this document.
 
 === iSchedule Receiver Actions
 
 iSchedule Receivers MUST provide a capabilities document to Senders, as per
 <<capabilities>>.
 
-Once the authenticity of the message is confirmed, the iSchedule Receiver delivers
-the scheduling message to the indicated recipients, collects and aggregates the
-delivery status for each recipient, and returns the result in the HTTP response body.
+Once the authenticity of the message is confirmed, the iSchedule Receiver
+delivers the scheduling message to the indicated recipients, collects and
+aggregates the delivery status for each recipient, and returns the result in the
+HTTP response body.
 
 In the event of a processing error related to the overall request, iSchedule
 Receivers MUST return an error response as per <<schedule-status-codes>>.

--- a/sources/sections/05-overview.adoc
+++ b/sources/sections/05-overview.adoc
@@ -1,0 +1,58 @@
+[[overview]]
+== iSchedule Overview
+
+This section provides an overview of the various steps involved for iSchedule
+Senders and Receivers to transmit scheduling messages between Calendar Services. It
+references later sections describing the precise details of each step.
+
+=== iSchedule Sender Actions
+
+A Calendar Service will generate an iTIP <<RFC5546>> scheduling message for
+transmission. It will additionally provide details of the Originator and Recipients.
+The Calendar Service will "submit" the scheduling message and details to the
+iSchedule Sender, through a process that is outside the scope of this document.
+
+The iSchedule Sender MUST verify the authenticity of the Originator and the
+Originator's authorization to send the scheduling message. In particular the
+"ORGANIZER" iCalendar property value MUST match the Originator calendar user
+address. The process by which this authentication and authorization is done is
+outside the scope of this document.
+
+For each Recipient, the iSchedule Sender will attempt to lookup a matching iSchedule
+Receiver to which the iSchedule message can be sent, following the rules in
+<<discovery>>. After determining the iSchedule Receiver to use, the iSchedule Sender
+MUST check the capabilities of the iSchedule Receiver to ensure it will be able to
+accept the scheduling message that needs to be sent, as per <<capabilities>>.
+
+The iSchedule Sender MUST group together Recipients for whom the iSchedule Receiver
+is the same, so that a single scheduling message is sent for multiple Recipients,
+within the limits of the <<max-recipients,IS:max-recipients>> value specified in the
+iSchedule Receiver's capabilities.
+
+For each group of Recipients handled by the same iSchedule Receiver, the iSchedule
+Sender will construct an HTTP request, as per <<scheduling>>, with the body of the
+HTTP request containing the iSchedule message. Note, in the case of a "VFREEBUSY"
+iSchedule message, the iSchedule Sender MUST ensure that iCalendar "ATTENDEE"
+properties in the iSchedule message match one-for-one with the Recipients listed in
+the HTTP request header.
+
+The iSchedule Sender then sends the HTTP request to the iSchedule Receiver handling
+the Recipient group, and receives the HTTP response, which will be an XML document
+with either an IS:schedule-response or IS:error element as the root element.
+
+The iSchedule Sender aggregates the results for each Recipient group receiving an
+iSchedule message, and returns the resulting status information for each Recipient
+to the Calendar Service that generated the schedule message. The process by which
+this is done is outside the scope of this document.
+
+=== iSchedule Receiver Actions
+
+iSchedule Receivers MUST provide a capabilities document to Senders, as per
+<<capabilities>>.
+
+Once the authenticity of the message is confirmed, the iSchedule Receiver delivers
+the scheduling message to the indicated recipients, collects and aggregates the
+delivery status for each recipient, and returns the result in the HTTP response body.
+
+In the event of a processing error related to the overall request, iSchedule
+Receivers MUST return an error response as per <<schedule-status-codes>>.

--- a/sources/sections/06-discovery.adoc
+++ b/sources/sections/06-discovery.adoc
@@ -1,0 +1,102 @@
+[[discovery]]
+== iSchedule Receiver Discovery
+
+This section describes how an iSchedule Sender can discover the host name, port, and
+the path to use to submit an HTTP request to an iSchedule Receiver.
+
+For each Recipient to whom a scheduling message is being sent, the iSchedule Sender
+will "resolve" the associated calendar user address into a domain name, as per
+<<cu-address-resolve>>.
+
+The iSchedule Sender then uses the extracted domain name to issue a DNS SRV query
+for the <<srv-type,iSchedule service>> expected to be hosted at the domain.
+
+The result of an SRV record lookup will be a target host name and a port, as per
+<<RFC2782>>. An iSchedule Sender uses these to contact the iSchedule Receiver.
+iSchedule Senders MUST honor the full behavior of SRV records, in particular the
+TTL, Priority and Weight options in the record, as well as handling multiple records
+being returned, as per <<RFC2782>>.
+
+Since an iSchedule Receiver is an HTTP server, an iSchedule Sender needs to supply a
+Request-URI in the HTTP request it makes to the iSchedule Receiver, in addition to
+the host name and port information. iSchedule Senders MUST use the path specified in
+any TXT records accompanying the SRV record (as per <<TXT>>), or in the absence of a
+matching TXT record, MUST use the .well-known URI (as per <<well-known>>).
+
+[[cu-address-resolve]]
+=== Resolving Calendar User Addresses
+
+To deliver a scheduling message via the iSchedule protocol, an iSchedule Sender
+needs to determine which iSchedule Receiver to use for a particular recipient. Each
+recipient's calendar user address is specified in one or more Recipient request
+headers.
+
+A calendar user address as defined by iCalendar is simply a URI. This is typically a
+mailto URI, but could potentially be any URI type. However, only URIs containing a
+"host" element can be used to extract the necessary information to locate an
+iSchedule Receiver.
+
+To get the SRV record name to query for a given mailto URI, the "domain" portion of
+the mailto URI is extracted and appended to the service label "_ischedules._tcp.".
+
+Example::
++
+[source%unnumbered]
+----
+Calendar User Address:  mailto:cyrus@example.com
+
+Query SRV Record Name: _ischedules._tcp.example.com
+----
+
+In cases where the "domain" portion of the mailto URI contains one or more levels of
+sub-domain, iSchedule Senders MAY choose to remove successive levels of "sub-domain"
+if queries for that sub-domain fail to return any SRV records. For example, a mailto
+URI with the full domain "host.calendar.example.com" would first trigger a query
+using the domain "host.calendar.example.com", then if that failed, the domain
+"calendar.example.com" would be tried, then if that failed the domain "example.com"
+would be tried.
+
+[[srv-type]]
+=== iSchedule SRV Service Type
+
+This specification adds an SRV service label for use with iSchedule:
+
+ischedules:: Identifies an iSchedule Receiver that uses HTTP with transport layer
+security (<<RFC2818>>).
+
+Example:: service record for iSchedule Receiver with transport layer security
++
+[source%unnumbered]
+----
+_ischedules._tcp.example.com. IN SRV 0 1 443 ischedule.example.com.
+----
+
+[[TXT]]
+=== iSchedule Service TXT Records
+
+When SRV RRs are used to advertise iSchedule services, it is also convenient to be
+able to specify a "context path" in the DNS to be retrieved at the same time. To
+enable that, this specification uses a TXT RR that follows the syntax defined in
+<<RFC6763,section=6>> and defines a "path" key for use in that record. The value of
+the key MUST be the actual "context path" to the corresponding service on the
+iSchedule Receiver.
+
+A site might provide TXT records in addition to SRV records for the service. When
+present, iSchedule Senders MUST use the "path" value as the "context path" for the
+service in HTTP requests. When not present, iSchedule Senders use the ".well-known"
+URI approach described next.
+
+Example:: text record for service with TLS
++
+[source%unnumbered]
+----
+_ischedules._tcp    TXT path=/ischedule
+----
+
+[[well-known]]
+=== iSchedule Receiver Request-URI
+
+This specification registers a well-known URI <<RFC5785>> for the iSchedule service,
+namely, "ischedule" (see
+<<IANA.WELL-KNOWN-URI>>). iSchedule Receivers MUST support requests targeted at this
+well-known URI. iSchedule Senders MUST handle HTTP redirects on this well-known URI.

--- a/sources/sections/06-discovery.adoc
+++ b/sources/sections/06-discovery.adoc
@@ -1,43 +1,45 @@
 [[discovery]]
 == iSchedule Receiver Discovery
 
-This section describes how an iSchedule Sender can discover the host name, port, and
-the path to use to submit an HTTP request to an iSchedule Receiver.
+This section describes how an iSchedule Sender can discover the host name, port,
+and the path to use to submit an HTTP request to an iSchedule Receiver.
 
-For each Recipient to whom a scheduling message is being sent, the iSchedule Sender
-will "resolve" the associated calendar user address into a domain name, as per
-<<cu-address-resolve>>.
+For each Recipient to whom a scheduling message is being sent, the iSchedule
+Sender will "resolve" the associated calendar user address into a domain name,
+as per <<cu-address-resolve>>.
 
-The iSchedule Sender then uses the extracted domain name to issue a DNS SRV query
-for the <<srv-type,iSchedule service>> expected to be hosted at the domain.
+The iSchedule Sender then uses the extracted domain name to issue a DNS SRV
+query for the <<srv-type,iSchedule service>> expected to be hosted at the
+domain.
 
 The result of an SRV record lookup will be a target host name and a port, as per
 <<RFC2782>>. An iSchedule Sender uses these to contact the iSchedule Receiver.
 iSchedule Senders MUST honor the full behavior of SRV records, in particular the
-TTL, Priority and Weight options in the record, as well as handling multiple records
-being returned, as per <<RFC2782>>.
+TTL, Priority and Weight options in the record, as well as handling multiple
+records being returned, as per <<RFC2782>>.
 
-Since an iSchedule Receiver is an HTTP server, an iSchedule Sender needs to supply a
-Request-URI in the HTTP request it makes to the iSchedule Receiver, in addition to
-the host name and port information. iSchedule Senders MUST use the path specified in
-any TXT records accompanying the SRV record (as per <<TXT>>), or in the absence of a
-matching TXT record, MUST use the .well-known URI (as per <<well-known>>).
+Since an iSchedule Receiver is an HTTP server, an iSchedule Sender needs to
+supply a Request-URI in the HTTP request it makes to the iSchedule Receiver, in
+addition to the host name and port information. iSchedule Senders MUST use the
+path specified in any TXT records accompanying the SRV record (as per <<TXT>>),
+or in the absence of a matching TXT record, MUST use the .well-known URI (as per
+<<well-known>>).
 
-[[cu-address-resolve]]
-=== Resolving Calendar User Addresses
+[[cu-address-resolve]] === Resolving Calendar User Addresses
 
 To deliver a scheduling message via the iSchedule protocol, an iSchedule Sender
-needs to determine which iSchedule Receiver to use for a particular recipient. Each
-recipient's calendar user address is specified in one or more Recipient request
-headers.
+needs to determine which iSchedule Receiver to use for a particular recipient.
+Each recipient's calendar user address is specified in one or more Recipient
+request headers.
 
-A calendar user address as defined by iCalendar is simply a URI. This is typically a
-mailto URI, but could potentially be any URI type. However, only URIs containing a
-"host" element can be used to extract the necessary information to locate an
-iSchedule Receiver.
+A calendar user address as defined by iCalendar is simply a URI. This is
+typically a mailto URI, but could potentially be any URI type. However, only
+URIs containing a "host" element can be used to extract the necessary
+information to locate an iSchedule Receiver.
 
-To get the SRV record name to query for a given mailto URI, the "domain" portion of
-the mailto URI is extracted and appended to the service label "_ischedules._tcp.".
+To get the SRV record name to query for a given mailto URI, the "domain" portion
+of the mailto URI is extracted and appended to the service label
+"_ischedules._tcp.".
 
 Example::
 +
@@ -48,13 +50,13 @@ Calendar User Address:  mailto:cyrus@example.com
 Query SRV Record Name: _ischedules._tcp.example.com
 ----
 
-In cases where the "domain" portion of the mailto URI contains one or more levels of
-sub-domain, iSchedule Senders MAY choose to remove successive levels of "sub-domain"
-if queries for that sub-domain fail to return any SRV records. For example, a mailto
-URI with the full domain "host.calendar.example.com" would first trigger a query
-using the domain "host.calendar.example.com", then if that failed, the domain
-"calendar.example.com" would be tried, then if that failed the domain "example.com"
-would be tried.
+In cases where the "domain" portion of the mailto URI contains one or more
+levels of sub-domain, iSchedule Senders MAY choose to remove successive levels
+of "sub-domain" if queries for that sub-domain fail to return any SRV records.
+For example, a mailto URI with the full domain "host.calendar.example.com" would
+first trigger a query using the domain "host.calendar.example.com", then if that
+failed, the domain "calendar.example.com" would be tried, then if that failed
+the domain "example.com" would be tried.
 
 [[srv-type]]
 === iSchedule SRV Service Type
@@ -74,17 +76,17 @@ _ischedules._tcp.example.com. IN SRV 0 1 443 ischedule.example.com.
 [[TXT]]
 === iSchedule Service TXT Records
 
-When SRV RRs are used to advertise iSchedule services, it is also convenient to be
-able to specify a "context path" in the DNS to be retrieved at the same time. To
-enable that, this specification uses a TXT RR that follows the syntax defined in
-<<RFC6763,section=6>> and defines a "path" key for use in that record. The value of
-the key MUST be the actual "context path" to the corresponding service on the
-iSchedule Receiver.
+When SRV RRs are used to advertise iSchedule services, it is also convenient to
+be able to specify a "context path" in the DNS to be retrieved at the same time.
+To enable that, this specification uses a TXT RR that follows the syntax defined
+in <<RFC6763,section=6>> and defines a "path" key for use in that record. The
+value of the key MUST be the actual "context path" to the corresponding service
+on the iSchedule Receiver.
 
-A site might provide TXT records in addition to SRV records for the service. When
-present, iSchedule Senders MUST use the "path" value as the "context path" for the
-service in HTTP requests. When not present, iSchedule Senders use the ".well-known"
-URI approach described next.
+A site might provide TXT records in addition to SRV records for the service.
+When present, iSchedule Senders MUST use the "path" value as the "context path"
+for the service in HTTP requests. When not present, iSchedule Senders use the
+".well-known" URI approach described next.
 
 Example:: text record for service with TLS
 +
@@ -96,7 +98,7 @@ _ischedules._tcp    TXT path=/ischedule
 [[well-known]]
 === iSchedule Receiver Request-URI
 
-This specification registers a well-known URI <<RFC5785>> for the iSchedule service,
-namely, "ischedule" (see
-<<IANA.WELL-KNOWN-URI>>). iSchedule Receivers MUST support requests targeted at this
-well-known URI. iSchedule Senders MUST handle HTTP redirects on this well-known URI.
+This specification registers a well-known URI <<RFC5785>> for the iSchedule
+service, namely, "ischedule" (see <<IANA.WELL-KNOWN-URI>>). iSchedule Receivers
+MUST support requests targeted at this well-known URI. iSchedule Senders MUST
+handle HTTP redirects on this well-known URI.

--- a/sources/sections/07-capabilities.adoc
+++ b/sources/sections/07-capabilities.adoc
@@ -1,0 +1,95 @@
+[[capabilities]]
+== iSchedule Receiver Capabilities
+
+iSchedule Receivers supporting the features described in this document MUST allow
+iSchedule Senders to query their capabilities by accepting GET requests targeted at
+the Request-URI found during discovery (<<discovery>>). The response body for a
+successful GET request targeted at this URI MUST be an XML document with
+IS:query-result as its root element.
+
+[NOTE]
+====
+Informative rationale: The GET method was favored over the POST method to allow
+iSchedule Senders to query capabilities with "conditional GET" requests (see
+<<RFC7232>>).
+====
+
+iSchedule Receivers SHOULD use normal HTTP expiration mechanisms (as per
+<<RFC7234,section=5.2>>) to ensure caches do not cache the capabilities response for
+too long. iSchedule Senders SHOULD use normal HTTP conditional GET requests when
+re-checking capabilities to avoid re-transferring already cached data.
+
+iSchedule Senders SHOULD use the information in the capabilities to determine
+whether the iSchedule Receiver supports a version of the protocol that the iSchedule
+Sender can use, and if not, not issue any iSchedule requests with scheduling
+messages to the iSchedule Receiver. iSchedule Senders SHOULD verify that the
+scheduling message to be sent to the iSchedule Receiver is in line with the
+restrictions on scheduling messages indicated by the capabilities before sending the
+scheduling message.
+
+[[ISCHEDULE_RECEIVER_CAPABILITIES_EXAMPLE]]
+=== Example: Querying iSchedule Receiver Capabilities
+
+.>> Request <<
+[source%unnumbered]
+----
+GET /.well-known/ischedule?action=capabilities HTTP/1.1
+Host: cal.example.com
+----
+
+.>> Response <<
+[source%unnumbered]
+----
+HTTP/1.1 200 OK
+Date: Mon, 15 Dec 2008 09:32:12 GMT
+Content-Type: application/xml; charset=utf-8
+Content-Length: xxxx
+iSchedule-Version: 1.0
+iSchedule-Capabilities: 123
+ETag: "afasdf-132afds"
+
+<?xml version="1.0" encoding="utf-8" ?>
+<query-result xmlns="urn:ietf:params:xml:ns:ischedule">
+  <capabilities>
+    <serial-number>123</serial-number>
+    <versions>
+      <version>1.0</version>
+    </versions>
+    <scheduling-messages>
+      <component name="VEVENT">
+        <method name="REQUEST"/>
+        <method name="ADD"/>
+        <method name="REPLY"/>
+        <method name="CANCEL"/>
+      </component>
+      <component name="VTODO">
+        <method name="REQUEST"/>
+        <method name="ADD"/>
+        <method name="REPLY"/>
+        <method name="CANCEL"/>
+      </component>
+      <component name="VFREEBUSY">
+        <method name="REQUEST"/>
+      </component>
+    </scheduling-messages>
+    <calendar-data-types>
+      <calendar-data-type
+       content-type="text/calendar" version="2.0"/>
+    </calendar-data-types>
+    <attachments>
+      <inline/>
+      <external/>
+    </attachments>
+    <rscales>
+      <rscale>GREGORIAN</rscale>
+      <rscale>CHINESE</rscale>
+    </rscales>
+    <max-content-length>102400</max-content-length>
+    <min-date-time>19910101T000000Z</min-date-time>
+    <max-date-time>20381231T000000Z</max-date-time>
+    <max-instances>150</max-instances>
+    <max-recipients>250</max-recipients>
+    <administrator>mailto:ischedule-admin@example.com</administrator>
+  </capabilities>
+</query-result>
+----

--- a/sources/sections/08-scheduling.adoc
+++ b/sources/sections/08-scheduling.adoc
@@ -1,0 +1,187 @@
+[[scheduling]]
+== Scheduling
+
+This section defines how an iSchedule Sender can use the HTTP POST method to submit
+a scheduling message to an iSchedule Receiver.
+
+[[schedule]]
+=== POST Method
+
+The POST method submits a scheduling message to one or more Recipients by targeting
+the request at the Request-URI of an iSchedule Receiver. The request body of a POST
+method MUST contain a scheduling message (i.e., an iCalendar object that follows the
+iTIP semantic).
+
+The submitted scheduling message will be delivered to the Recipients, with status
+information about per-recipient delivery returned in the HTTP response. However,
+when the scheduling message is a request for free-busy time, the iSchedule Receiver
+will immediately execute the free-busy request for the Recipients and return
+per-recipient iCalendar data in the response for successful free-busy queries.
+
+Every POST request MUST include the
+<<IANA_HTTP_ISCHEDULE_VERSION,"iSchedule-Version">> general header.
+
+Every POST request SHOULD include the
+<<IANA_HTTP_ISCHEDULE_MESSAGE_ID,"iSchedule-Message-ID">> request header.
+
+Every POST request MUST include the "Cache-Control" HTTP general header containing
+the cache-directives "no-cache" and "no-transform" to prevent intermediary caches
+from caching or transforming responses.
+
+Every POST request MUST include a single <<IANA_HTTP_ORIGINATOR,"Originator">>
+request header that specifies the calendar user address of the Originator of the
+scheduling message. The value of the "Originator" request header MUST match the
+value of the "ORGANIZER" iCalendar property or one of the specified "ATTENDEE"
+iCalendar properties in the scheduling message, depending on the specified "METHOD"
+iCalendar property value as summarized in the following table:
+
+[options=header,cols=2]
+|===
+|Method |Originator Requirement
+
+|PUBLISH |MUST match ORGANIZER
+|REQUEST |MUST match ORGANIZER footnote:f1[iTIP does allow an Attendee to forward a "METHOD:REQUEST" scheduling message to another attendee. However, due to complexity of managing the authorization of such requests, this specification does not allow scheduling message forwarding.]
+|REPLY |MUST match ATTENDEE
+|ADD |MUST match ORGANIZER
+|CANCEL |MUST match ORGANIZER
+|REFRESH |MUST match ATTENDEE
+|COUNTER |MUST match ATTENDEE
+|DECLINECOUNTER |MUST match ORGANIZER
+|===
+
+Every POST request MUST include one or more <<IANA_HTTP_RECIPIENT,"Recipient">>
+request headers. The value of this header is a list of one or more calendar user
+addresses and corresponds to the set of calendar users who will have the scheduling
+message delivered to them. The value of the "Recipient" request header MUST match
+the value of the "ORGANIZER" iCalendar property or one of the specified "ATTENDEE"
+iCalendar properties in the scheduling message, depending on the specified "METHOD"
+iCalendar property value as summarized in the following table:
+
+[options=header,cols=2]
+|===
+|Method |Recipient Requirement
+
+|PUBLISH |None footnote:f2[iTIP does allow an Organizer to send scheduling message to calendar users who are not listed as Attendees, e.g., to inform other calendar users of an event taking place. However, due to complexity of managing the authorization of such requests, this specification does not allow such scheduling messages.]
+|REQUEST |MUST match ATTENDEE footnote:f2[]
+|REPLY |MUST match ORGANIZER
+|ADD |MUST match ATTENDEE footnote:f2[]
+|CANCEL |MUST match ATTENDEE footnote:f2[]
+|REFRESH |MUST match ORGANIZER
+|COUNTER |MUST match ORGANIZER
+|DECLINECOUNTER |MUST match ATTENDEE
+|===
+
+The Content-Type general header MUST include the type parameters "component" and
+"method" defined in <<RFC5545>>. The value of the "component" MUST correspond to the
+iCalendar component type (e.g., "VEVENT") specified in the scheduling message. The
+value of the "method" parameter MUST be the same as the value of the "METHOD"
+iCalendar property in the scheduling message. If iCalendar data is returned in the
+response, within an IS:calendar-data XML element, then the media type of that data
+in the response MUST match the media type in the request.
+
+[[schedule-response]]
+=== Schedule Response
+
+A POST request may deliver a scheduling message to one or more calendar users
+specified in the Recipient request header. Since the behavior of each recipient may
+vary, it is useful to get response status information for each recipient in the
+overall POST response. This specification defines a new XML response to convey
+multiple recipient status.
+
+A response to a POST method that indicates status for one or more recipients MUST be
+an XML document with IS:schedule-response as its root element. This MUST contain one
+or more response elements for each recipient, with each of those containing elements
+that indicate which recipient they correspond to, the scheduling status of the
+request for that recipient, any error codes and an optional description.
+
+In the case of a free-busy request, the response elements can also contain
+calendar-data elements which contain free busy information (e.g., an iCalendar
+VFREEBUSY component) indicating the busy state of the corresponding recipient,
+assuming that the free-busy request for that recipient succeeded.
+
+Every POST response MUST include the "Cache-Control" HTTP general header containing
+the cache-directives "no-cache" and "no-transform" to prevent intermediary caches
+from caching or transforming responses.
+
+[[schedule-status-codes]]
+=== Failed Schedule Response
+
+When there is an overall, as opposed to per-recipient, failure of the POST request,
+the iSchedule Receiver SHOULD return an XML document with IS:error as its root
+element. The child elements of the IS:error element are used to indicate an error
+code and description, primarily meant for service administrators.
+
+The following XML elements are error codes which can be used within an IS:error
+element to represent errors:
+
+IS:version-not-supported:: The POST request was either missing an
+"iSchedule-Version" header, or had an "iSchedule-Version" header value for a version
+not supported by the iSchedule Receiver, as advertised in the IS:versions capability.
+
+IS:invalid-calendar-data-type:: The resource submitted in the POST request was not a
+supported media type (i.e. text/calendar) for scheduling or free-busy messages;
+
+IS:invalid-calendar-data:: The resource submitted in the POST request was not valid
+data for the media type being specified;
+
+IS:invalid-scheduling-message:: The resource submitted in the POST request did not
+obey all restrictions specified for the POST request, violating the
+IS:scheduling-message capability element, or the requirements of iTIP;
+
+IS:originator-missing:: The POST request did not include an "Originator" request
+header specifying the calendar user address of the Originator of the scheduling
+message.
+
+IS:too-many-originators:: The POST request contained more than one "Originator"
+request header.
+
+IS:originator-invalid:: The "Originator" header in the POST request did not include
+a valid calendar user address for the Originator of the scheduling message.
+
+IS:originator-denied:: The calendar user identified by the "Originator" header in
+the POST request is not allowed to use this service.
+
+IS:recipient-missing:: The POST request did not include one or more valid
+"Recipient" request headers specifying the calendar user address of users to whom
+the scheduling message will be delivered.
+
+IS:recipient-mismatch:: The POST request did not include "Recipient" request header
+values which exactly match the list of "ATTENDEE" property values in a "VFREEBUSY"
+request.
+
+IS:max-recipients:: The POST request had too many calendar user addresses specified
+in "Recipient" request headers, violating the IS:max-recipients capability.
+
+IS:attachment-type-not-supported:: The scheduling message submitted in the POST
+request had iCalendar data with "ATTACH" properties whose value type is not
+supported, violating the IS:attachments capability.
+
+IS:max-content-length:: The scheduling message submitted in the POST request had
+iCalendar data violating the IS:max-content-length capability.
+
+IS:min-date-time:: The scheduling message submitted in the POST request had
+iCalendar data violating the IS:min-date-time capability.
+
+IS:max-date-time:: The scheduling message submitted in the POST request had
+iCalendar data violating the IS:max-date-time capability.
+
+IS:max-instances:: The scheduling message submitted in the POST request had
+iCalendar data violating the IS:max-instances capability.
+
+The following are examples of response codes one would expect to be used for this
+method. Note, however, that unless explicitly prohibited any 2/3/4/5xx series
+response code may be used in a response. Typically a 403 response code would be used
+when an XML document with an IS:error element as its root is also returned.
+
+200 (OK):: The command succeeded.
+
+400 (Bad Request):: The Sender has provided an invalid scheduling message, or
+invalid iSchedule request headers.
+
+403 (Forbidden):: The Sender cannot submit a scheduling message to the specified
+Request-URI.
+
+404 (Not Found):: The URL in the Request-URI was not present.
+
+507 (Insufficient Storage):: The server did not have sufficient space to record the
+scheduling message.

--- a/sources/sections/08-scheduling.adoc
+++ b/sources/sections/08-scheduling.adoc
@@ -1,22 +1,23 @@
 [[scheduling]]
 == Scheduling
 
-This section defines how an iSchedule Sender can use the HTTP POST method to submit
-a scheduling message to an iSchedule Receiver.
+This section defines how an iSchedule Sender can use the HTTP POST method to
+submit a scheduling message to an iSchedule Receiver.
 
 [[schedule]]
 === POST Method
 
-The POST method submits a scheduling message to one or more Recipients by targeting
-the request at the Request-URI of an iSchedule Receiver. The request body of a POST
-method MUST contain a scheduling message (i.e., an iCalendar object that follows the
-iTIP semantic).
+The POST method submits a scheduling message to one or more Recipients by
+targeting the request at the Request-URI of an iSchedule Receiver. The request
+body of a POST method MUST contain a scheduling message (i.e., an iCalendar
+object that follows the iTIP semantic).
 
-The submitted scheduling message will be delivered to the Recipients, with status
-information about per-recipient delivery returned in the HTTP response. However,
-when the scheduling message is a request for free-busy time, the iSchedule Receiver
-will immediately execute the free-busy request for the Recipients and return
-per-recipient iCalendar data in the response for successful free-busy queries.
+The submitted scheduling message will be delivered to the Recipients, with
+status information about per-recipient delivery returned in the HTTP response.
+However, when the scheduling message is a request for free-busy time, the
+iSchedule Receiver will immediately execute the free-busy request for the
+Recipients and return per-recipient iCalendar data in the response for
+successful free-busy queries.
 
 Every POST request MUST include the
 <<IANA_HTTP_ISCHEDULE_VERSION,"iSchedule-Version">> general header.
@@ -24,44 +25,56 @@ Every POST request MUST include the
 Every POST request SHOULD include the
 <<IANA_HTTP_ISCHEDULE_MESSAGE_ID,"iSchedule-Message-ID">> request header.
 
-Every POST request MUST include the "Cache-Control" HTTP general header containing
-the cache-directives "no-cache" and "no-transform" to prevent intermediary caches
-from caching or transforming responses.
+Every POST request MUST include the "Cache-Control" HTTP general header
+containing the cache-directives "no-cache" and "no-transform" to prevent
+intermediary caches from caching or transforming responses.
 
 Every POST request MUST include a single <<IANA_HTTP_ORIGINATOR,"Originator">>
 request header that specifies the calendar user address of the Originator of the
 scheduling message. The value of the "Originator" request header MUST match the
 value of the "ORGANIZER" iCalendar property or one of the specified "ATTENDEE"
-iCalendar properties in the scheduling message, depending on the specified "METHOD"
-iCalendar property value as summarized in the following table:
+iCalendar properties in the scheduling message, depending on the specified
+"METHOD" iCalendar property value as summarized in the following table:
 
 [options=header,cols=2]
 |===
 |Method |Originator Requirement
 
 |PUBLISH |MUST match ORGANIZER
-|REQUEST |MUST match ORGANIZER footnote:f1[iTIP does allow an Attendee to forward a "METHOD:REQUEST" scheduling message to another attendee. However, due to complexity of managing the authorization of such requests, this specification does not allow scheduling message forwarding.]
+|REQUEST |MUST match ORGANIZER
+footnote:f1[iTIP does allow an Attendee to forward a "METHOD:REQUEST" scheduling
+message to another attendee. However, due to complexity of managing the
+authorization of such requests, this specification does not allow scheduling
+message forwarding.]
+
 |REPLY |MUST match ATTENDEE
 |ADD |MUST match ORGANIZER
 |CANCEL |MUST match ORGANIZER
 |REFRESH |MUST match ATTENDEE
 |COUNTER |MUST match ATTENDEE
 |DECLINECOUNTER |MUST match ORGANIZER
+
 |===
 
 Every POST request MUST include one or more <<IANA_HTTP_RECIPIENT,"Recipient">>
 request headers. The value of this header is a list of one or more calendar user
-addresses and corresponds to the set of calendar users who will have the scheduling
-message delivered to them. The value of the "Recipient" request header MUST match
-the value of the "ORGANIZER" iCalendar property or one of the specified "ATTENDEE"
-iCalendar properties in the scheduling message, depending on the specified "METHOD"
-iCalendar property value as summarized in the following table:
+addresses and corresponds to the set of calendar users who will have the
+scheduling message delivered to them. The value of the "Recipient" request
+header MUST match the value of the "ORGANIZER" iCalendar property or one of the
+specified "ATTENDEE" iCalendar properties in the scheduling message, depending
+on the specified "METHOD" iCalendar property value as summarized in the
+following table:
 
 [options=header,cols=2]
 |===
 |Method |Recipient Requirement
 
-|PUBLISH |None footnote:f2[iTIP does allow an Organizer to send scheduling message to calendar users who are not listed as Attendees, e.g., to inform other calendar users of an event taking place. However, due to complexity of managing the authorization of such requests, this specification does not allow such scheduling messages.]
+|PUBLISH |None
+footnote:f2[iTIP does allow an Organizer to send scheduling message to calendar
+users who are not listed as Attendees, e.g., to inform other calendar users of
+an event taking place. However, due to complexity of managing the authorization
+of such requests, this specification does not allow such scheduling messages.]
+
 |REQUEST |MUST match ATTENDEE footnote:f2[]
 |REPLY |MUST match ORGANIZER
 |ADD |MUST match ATTENDEE footnote:f2[]
@@ -69,63 +82,68 @@ iCalendar property value as summarized in the following table:
 |REFRESH |MUST match ORGANIZER
 |COUNTER |MUST match ORGANIZER
 |DECLINECOUNTER |MUST match ATTENDEE
+
 |===
 
 The Content-Type general header MUST include the type parameters "component" and
-"method" defined in <<RFC5545>>. The value of the "component" MUST correspond to the
-iCalendar component type (e.g., "VEVENT") specified in the scheduling message. The
-value of the "method" parameter MUST be the same as the value of the "METHOD"
-iCalendar property in the scheduling message. If iCalendar data is returned in the
-response, within an IS:calendar-data XML element, then the media type of that data
-in the response MUST match the media type in the request.
+"method" defined in <<RFC5545>>. The value of the "component" MUST correspond to
+the iCalendar component type (e.g., "VEVENT") specified in the scheduling
+message. The value of the "method" parameter MUST be the same as the value of
+the "METHOD" iCalendar property in the scheduling message. If iCalendar data is
+returned in the response, within an IS:calendar-data XML element, then the media
+type of that data in the response MUST match the media type in the request.
 
 [[schedule-response]]
 === Schedule Response
 
 A POST request may deliver a scheduling message to one or more calendar users
-specified in the Recipient request header. Since the behavior of each recipient may
-vary, it is useful to get response status information for each recipient in the
-overall POST response. This specification defines a new XML response to convey
-multiple recipient status.
+specified in the Recipient request header. Since the behavior of each recipient
+may vary, it is useful to get response status information for each recipient in
+the overall POST response. This specification defines a new XML response to
+convey multiple recipient status.
 
-A response to a POST method that indicates status for one or more recipients MUST be
-an XML document with IS:schedule-response as its root element. This MUST contain one
-or more response elements for each recipient, with each of those containing elements
-that indicate which recipient they correspond to, the scheduling status of the
-request for that recipient, any error codes and an optional description.
+A response to a POST method that indicates status for one or more recipients
+MUST be an XML document with IS:schedule-response as its root element. This MUST
+contain one or more response elements for each recipient, with each of those
+containing elements that indicate which recipient they correspond to, the
+scheduling status of the request for that recipient, any error codes and an
+optional description.
 
 In the case of a free-busy request, the response elements can also contain
 calendar-data elements which contain free busy information (e.g., an iCalendar
 VFREEBUSY component) indicating the busy state of the corresponding recipient,
 assuming that the free-busy request for that recipient succeeded.
 
-Every POST response MUST include the "Cache-Control" HTTP general header containing
-the cache-directives "no-cache" and "no-transform" to prevent intermediary caches
-from caching or transforming responses.
+Every POST response MUST include the "Cache-Control" HTTP general header
+containing the cache-directives "no-cache" and "no-transform" to prevent
+intermediary caches from caching or transforming responses.
 
 [[schedule-status-codes]]
 === Failed Schedule Response
 
-When there is an overall, as opposed to per-recipient, failure of the POST request,
-the iSchedule Receiver SHOULD return an XML document with IS:error as its root
-element. The child elements of the IS:error element are used to indicate an error
-code and description, primarily meant for service administrators.
+When there is an overall, as opposed to per-recipient, failure of the POST
+request, the iSchedule Receiver SHOULD return an XML document with IS:error as
+its root element. The child elements of the IS:error element are used to
+indicate an error code and description, primarily meant for service
+administrators.
 
 The following XML elements are error codes which can be used within an IS:error
 element to represent errors:
 
 IS:version-not-supported:: The POST request was either missing an
-"iSchedule-Version" header, or had an "iSchedule-Version" header value for a version
-not supported by the iSchedule Receiver, as advertised in the IS:versions capability.
+"iSchedule-Version" header, or had an "iSchedule-Version" header value for a
+version not supported by the iSchedule Receiver, as advertised in the
+IS:versions capability.
 
-IS:invalid-calendar-data-type:: The resource submitted in the POST request was not a
-supported media type (i.e. text/calendar) for scheduling or free-busy messages;
+IS:invalid-calendar-data-type:: The resource submitted in the POST request was
+not a supported media type (i.e. text/calendar) for scheduling or free-busy
+messages;
 
-IS:invalid-calendar-data:: The resource submitted in the POST request was not valid
-data for the media type being specified;
+IS:invalid-calendar-data:: The resource submitted in the POST request was not
+valid data for the media type being specified;
 
-IS:invalid-scheduling-message:: The resource submitted in the POST request did not
-obey all restrictions specified for the POST request, violating the
+IS:invalid-scheduling-message:: The resource submitted in the POST request did
+not obey all restrictions specified for the POST request, violating the
 IS:scheduling-message capability element, or the requirements of iTIP;
 
 IS:originator-missing:: The POST request did not include an "Originator" request
@@ -135,22 +153,24 @@ message.
 IS:too-many-originators:: The POST request contained more than one "Originator"
 request header.
 
-IS:originator-invalid:: The "Originator" header in the POST request did not include
-a valid calendar user address for the Originator of the scheduling message.
+IS:originator-invalid:: The "Originator" header in the POST request did not
+include a valid calendar user address for the Originator of the scheduling
+message.
 
-IS:originator-denied:: The calendar user identified by the "Originator" header in
-the POST request is not allowed to use this service.
+IS:originator-denied:: The calendar user identified by the "Originator" header
+in the POST request is not allowed to use this service.
 
 IS:recipient-missing:: The POST request did not include one or more valid
-"Recipient" request headers specifying the calendar user address of users to whom
-the scheduling message will be delivered.
+"Recipient" request headers specifying the calendar user address of users to
+whom the scheduling message will be delivered.
 
-IS:recipient-mismatch:: The POST request did not include "Recipient" request header
-values which exactly match the list of "ATTENDEE" property values in a "VFREEBUSY"
-request.
+IS:recipient-mismatch:: The POST request did not include "Recipient" request
+header values which exactly match the list of "ATTENDEE" property values in a
+"VFREEBUSY" request.
 
-IS:max-recipients:: The POST request had too many calendar user addresses specified
-in "Recipient" request headers, violating the IS:max-recipients capability.
+IS:max-recipients:: The POST request had too many calendar user addresses
+specified in "Recipient" request headers, violating the IS:max-recipients
+capability.
 
 IS:attachment-type-not-supported:: The scheduling message submitted in the POST
 request had iCalendar data with "ATTACH" properties whose value type is not
@@ -168,10 +188,11 @@ iCalendar data violating the IS:max-date-time capability.
 IS:max-instances:: The scheduling message submitted in the POST request had
 iCalendar data violating the IS:max-instances capability.
 
-The following are examples of response codes one would expect to be used for this
-method. Note, however, that unless explicitly prohibited any 2/3/4/5xx series
-response code may be used in a response. Typically a 403 response code would be used
-when an XML document with an IS:error element as its root is also returned.
+The following are examples of response codes one would expect to be used for
+this method. Note, however, that unless explicitly prohibited any 2/3/4/5xx
+series response code may be used in a response. Typically a 403 response code
+would be used when an XML document with an IS:error element as its root is also
+returned.
 
 200 (OK):: The command succeeded.
 
@@ -183,5 +204,5 @@ Request-URI.
 
 404 (Not Found):: The URL in the Request-URI was not present.
 
-507 (Insufficient Storage):: The server did not have sufficient space to record the
-scheduling message.
+507 (Insufficient Storage):: The server did not have sufficient space to record
+the scheduling message.

--- a/sources/sections/09-http-headers.adoc
+++ b/sources/sections/09-http-headers.adoc
@@ -1,0 +1,85 @@
+[[http.headers]]
+== HTTP Headers
+
+This section defines the syntax and semantics of additional HTTP/1.1 header fields.
+
+The header's syntax uses the optional whitespace (OWS) rule defined as follows:
+
+[source%unnumbered]
+----
+OWS = *( [ CRLF ] WSP )
+----
+
+[[ischedule-version.header]]
+=== iSchedule-Version General Header
+
+The "iSchedule-Version" general header field MUST be specified by the iSchedule
+Sender on requests, and by the iSchedule Receiver on responses. It SHOULD be
+included in a response to any "OPTIONS *" HTTP request targeting the iSchedule
+Receiver, or any "OPTIONS" request on a resource supporting the iSchedule behaviors
+described in this specification (e.g., the .well-known resource or any resource that
+.well-known redirects to).
+
+[source%unnumbered]
+----
+iSchedule-Version      = "iSchedule-Version" ":" OWS
+                         iSchedule-Version-v
+iSchedule-Version-v    = iSchedule-Version-elem
+                         *( OWS "," OWS iSchedule-Version-elem )
+iSchedule-Version-elem =  1*DIGIT "." 1*DIGIT
+----
+
+[[ischedule-capabilities.header]]
+=== iSchedule-Capabilities Response Header
+
+The "iSchedule-Capabilities" response header field MUST be specified by the
+iSchedule Receiver on all responses. iSchedule Senders SHOULD cache this value and
+use it to detect a change in the iSchedule Receiver capabilities that cause the
+iSchedule Sender to reload capabilities. The value of this header is maintained by
+the iSchedule Receiver as described in <<capabilities_serial_number>>.
+
+[source%unnumbered]
+----
+iSchedule-Capabilities = "iSchedule-Capabilities" ":" OWS 1*DIGIT
+----
+
+[[ischedule-message-id.header]]
+=== iSchedule-Message-ID Request Header
+
+The "iSchedule-Message-ID" request header field SHOULD be specified by the iSchedule
+Sender on requests. This header provides a unique identifier that refers to the
+specific iSchedule request in which it is included. The uniqueness of this
+identifier is guaranteed by the iSchedule Sender that generates it. This identifier
+is intended to be machine readable and not necessarily meaningful to humans.
+
+[source%unnumbered]
+----
+iSchedule-Message-ID   = "iSchedule-Message-ID" ":" OWS token
+----
+
+[[originator.header]]
+=== Originator Request Header
+
+The "Originator" request header value is a URI which specifies the calendar user
+address of the originator of the scheduling message. Note that the absoluteURI rule
+is defined in <<RFC3986>>.
+
+[source%unnumbered]
+----
+Originator   = "Originator" ":" OWS Originator-v
+Originator-v = absoluteURI
+----
+
+[[recipient.header]]
+=== Recipient Request Header
+
+The "Recipient" request header value is a URI which specifies the calendar user
+address of the recipients to which the POST method should deliver the submitted
+scheduling message. Note that the absoluteURI rule is defined in <<RFC3986>>.
+
+[source%unnumbered]
+----
+Recipient      = "Recipient" ":" OWS Recipient-v
+Recipient-v    = Recipient-elem *( OWS "," OWS Recipient-elem )
+Recipient-elem = absoluteURI
+----

--- a/sources/sections/09-http-headers.adoc
+++ b/sources/sections/09-http-headers.adoc
@@ -1,7 +1,8 @@
 [[http.headers]]
 == HTTP Headers
 
-This section defines the syntax and semantics of additional HTTP/1.1 header fields.
+This section defines the syntax and semantics of additional HTTP/1.1 header
+fields.
 
 The header's syntax uses the optional whitespace (OWS) rule defined as follows:
 
@@ -16,9 +17,9 @@ OWS = *( [ CRLF ] WSP )
 The "iSchedule-Version" general header field MUST be specified by the iSchedule
 Sender on requests, and by the iSchedule Receiver on responses. It SHOULD be
 included in a response to any "OPTIONS *" HTTP request targeting the iSchedule
-Receiver, or any "OPTIONS" request on a resource supporting the iSchedule behaviors
-described in this specification (e.g., the .well-known resource or any resource that
-.well-known redirects to).
+Receiver, or any "OPTIONS" request on a resource supporting the iSchedule
+behaviors described in this specification (e.g., the .well-known resource or any
+resource that .well-known redirects to).
 
 [source%unnumbered]
 ----
@@ -33,10 +34,11 @@ iSchedule-Version-elem =  1*DIGIT "." 1*DIGIT
 === iSchedule-Capabilities Response Header
 
 The "iSchedule-Capabilities" response header field MUST be specified by the
-iSchedule Receiver on all responses. iSchedule Senders SHOULD cache this value and
-use it to detect a change in the iSchedule Receiver capabilities that cause the
-iSchedule Sender to reload capabilities. The value of this header is maintained by
-the iSchedule Receiver as described in <<capabilities_serial_number>>.
+iSchedule Receiver on all responses. iSchedule Senders SHOULD cache this value
+and use it to detect a change in the iSchedule Receiver capabilities that cause
+the iSchedule Sender to reload capabilities. The value of this header is
+maintained by the iSchedule Receiver as described in
+<<capabilities_serial_number>>.
 
 [source%unnumbered]
 ----
@@ -46,11 +48,12 @@ iSchedule-Capabilities = "iSchedule-Capabilities" ":" OWS 1*DIGIT
 [[ischedule-message-id.header]]
 === iSchedule-Message-ID Request Header
 
-The "iSchedule-Message-ID" request header field SHOULD be specified by the iSchedule
-Sender on requests. This header provides a unique identifier that refers to the
-specific iSchedule request in which it is included. The uniqueness of this
-identifier is guaranteed by the iSchedule Sender that generates it. This identifier
-is intended to be machine readable and not necessarily meaningful to humans.
+The "iSchedule-Message-ID" request header field SHOULD be specified by the
+iSchedule Sender on requests. This header provides a unique identifier that
+refers to the specific iSchedule request in which it is included. The uniqueness
+of this identifier is guaranteed by the iSchedule Sender that generates it. This
+identifier is intended to be machine readable and not necessarily meaningful to
+humans.
 
 [source%unnumbered]
 ----
@@ -61,8 +64,8 @@ iSchedule-Message-ID   = "iSchedule-Message-ID" ":" OWS token
 === Originator Request Header
 
 The "Originator" request header value is a URI which specifies the calendar user
-address of the originator of the scheduling message. Note that the absoluteURI rule
-is defined in <<RFC3986>>.
+address of the originator of the scheduling message. Note that the absoluteURI
+rule is defined in <<RFC3986>>.
 
 [source%unnumbered]
 ----

--- a/sources/sections/10-xml-elements.adoc
+++ b/sources/sections/10-xml-elements.adoc
@@ -1,0 +1,429 @@
+[[xml-elements]]
+== XML Element Definitions
+
+[[schedule_response_element]]
+=== schedule-response XML Element
+
+Name:: schedule-response
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Contains the set of responses for a POST method request.
+Description:: See <<schedule-response>>.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT schedule-response (response*)>
+----
+
+[[response_element]]
+==== response XML Element
+
+Name:: response
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Contains a single response for a POST method request.
+Description:: See <<schedule-response>>.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT response (recipient,
+                   request-status,
+                   calendar-data?,
+                   error?,
+                   response-description?)>
+----
+
+[[recipient_element]]
+===== recipient XML Element
+
+Name:: recipient
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: The calendar user address (recipient header value) that the enclosing response for a POST method request is for.
+Description:: See <<schedule-response>>.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT recipient (#PCDATA)>
+----
+
+[[response_status_element]]
+===== request-status XML Element
+
+Name:: request-status
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: The iTIP REQUEST-STATUS property value for this response.
+Description:: See <<schedule-response>>.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT request-status (#PCDATA)>
+----
+
+===== calendar-data XML Element
+
+Name:: calendar-data
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: An iCalendar object in a response to a search for busy time information.
+Description:: See <<schedule-response>>.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT calendar-data (#PCDATA)>
+<!ATTLIST calendar-data content-type CDATA "text/calendar"
+                        version CDATA "2.0">
+<!-- content-type value: a MIME media type -->
+<!-- version value: a version string -->
+----
+
+===== error XML Element
+
+Name:: error
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Error responses sometimes need more information to indicate what went wrong.
+Description:: See <<schedule-response>>.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT error ANY>
+----
+
+===== response-description XML Element
+
+Name:: response-description
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Contains information about a status response
+Description:: See <<schedule-response>>.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT response-description (#PCDATA)>
+----
+
+=== query-result XML Element
+
+Name:: query-result
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Contains result of a query request.
+Description:: A generic container for the result of a query request, such as a query of the capabilities of an iSchedule Receiver.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT query-result (capabilities)>
+----
+
+==== capabilities XML Element
+
+Name:: capabilities
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Contains iSchedule Receiver capabilities.
+Description:: The capabilities element contains capabilities of the iSchedule Receiver.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT capabilities (
+    serial-number,
+    versions,
+    scheduling-messages,
+    calendar-data-types,
+    attachments,
+    rscales,
+    max-content-length,
+    min-date-time,
+    max-date-time,
+    max-instances,
+    max-recipients,
+    administrator) >
+----
+
+[[capabilities_serial_number]]
+===== serial-number XML Element
+
+Name:: serial-number
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies the version of the capabilities information.
+Description:: This is a numeric value maintained by the iSchedule Receiver. The
+value is incremented by the iSchedule Receiver each time there has been a
+substantive change to the capabilities that would require an iSchedule Sender to
+reload the capabilities to adjust its behavior. The value of this element MUST be
+returned by the iSchedule Receiver in all HTTP requests via the
+<<ischedule-capabilities.header,"iSchedule-Capabilities" response header>>. This
+allows iSchedule Senders to detect changes to the iSchedule Receiver's capabilities
+during the normal course of making requests, without the need to poll the iSchedule
+Receiver for such changes.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT serial-number (#PCDATA)>
+<!-- PCDATA value: a numeric value (positive integer) -->
+----
+
+===== versions XML Element
+
+Name:: versions
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies the iSchedule versions supported by the iSchedule Receiver.
+Description:: An iSchedule Receiver MAY advertise support for multiple versions of
+the iSchedule protocol. iSchedule Senders check this value to ensure they can send
+iSchedule messages with a matching version.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT versions (version)+>
+----
+
+====== version XML Element
+
+Name:: version
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies an iSchedule protocol version.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT version (#PCDATA)>
+<!-- PCDATA value: version number -->
+----
+
+===== scheduling-messages XML Element
+
+Name:: scheduling-messages
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies the type of supported scheduling messages.
+Description:: An iSchedule Receiver advertises which iCalendar component types it
+will accept for iTIP messages sent to it. In addition, for each component, it can
+specify the allowed iTIP "METHOD" property values.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT scheduling-messages (component)+>
+----
+
+====== component XML Element
+
+Name:: component
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies a calendar component type.
+Description:: Used to specify a supported iCalendar component type for scheduling
+messages. If a IS:method child element is not present, then any iTIP "METHOD"
+property value can be used in iTIP messages sent to the iSchedule Receiver. If one
+or more IS:method elements are present, then those indicate the allowed set of iTIP
+"METHOD" property values.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT component (method)*>
+
+<!ATTLIST component name CDATA #REQUIRED>
+<!-- name value: a calendar component name -->
+----
+
+[level=6]
+====== method XML Element
+
+Name:: method
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies an iCalendar method type.
+Description:: See IS:component.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT method EMPTY>
+
+<!ATTLIST method name CDATA #REQUIRED>
+<!-- name value: a method type -->
+----
+
+===== calendar-data-types XML Element
+
+Name:: calendar-data-types
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies what formats of iCalendar data are acceptable.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT calendar-data-types (calendar-data-type)+>
+----
+
+====== calendar-data-type XML Element
+
+Name:: calendar-data-type
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies a supported media type and version for iTIP messages.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT calendar-data-type EMPTY>
+
+<!ATTLIST calendar-data-type content-type CDATA "text/calendar"
+                             version CDATA "2.0">
+<!-- content-type value: a MIME media type -->
+<!-- version value: a version string -->
+----
+
+===== attachments XML Element
+
+Name:: attachments
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies the attachment values supported.
+Description:: iSchedule Receivers might restrict what form of attachments are
+allowed in iTIP messages that are sent to it, for performance, or security reasons.
+In iCalendar data, attachments can either be specified using "inline" data in the
+form of a base64 encoded property value, or "external" data in the form of a URI
+property value. With this capability, an iSchedule Receiver can specify which of
+"inline" or "external" values it will accept in iTIP messages. See
+<<security_attachments>> for additional details.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT attachments (inline?, external?)>
+----
+
+====== inline XML Element
+
+Name:: inline
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies "inline" attachments as a supported attachment value.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT inline EMPTY>
+----
+
+====== external XML Element
+
+Name:: external
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies "external" attachments as a supported attachment value.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT external EMPTY>
+----
+
+===== rscales XML Element
+
+Name:: rscales
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies the "RSCALE" values supported.
+Description:: iSchedule Receivers might support the <<RFC7529,iCalendar "RSCALE">>
+element on the "RRULE" property. The iSchedule Receiver can advertise what "RSCALE"
+values are supported via the IS:rscales element.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT rscales (rscale*)>
+----
+
+====== rscale XML Element
+
+Name:: rscale
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Indicates a supported "RSCALE" value.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT rscale (#PCDATA)>
+----
+
+===== max-content-length XML Element
+
+Name:: max-content-length
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Identifies the maximum size allowed for a scheduling message in octets.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT max-content-length (#PCDATA)>
+<!-- PCDATA value: a numeric value (positive integer) -->
+----
+
+===== min-date-time XML Element
+
+Name:: min-date-time
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: A DATE-TIME value indicating the earliest date and time in UTC that the
+iSchedule Receiver is willing to accept for any DATE or DATE-TIME value in a
+scheduling message.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT min-date-time (#PCDATA)>
+<!-- PCDATA value: an iCalendar format DATE-TIME value in UTC -->
+----
+
+===== max-date-time XML Element
+
+Name:: max-date-time
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: A DATE-TIME value indicating the latest date and time in UTC that the
+iSchedule Receiver is willing to accept for any DATE or DATE-TIME value in a
+scheduling message.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT max-date-time (#PCDATA)>
+<!-- PCDATA value: an iCalendar format DATE-TIME value in UTC -->
+----
+
+===== max-instances XML Element
+
+Name:: max-instances
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: The maximum number of recurrence instances allowed in a scheduling message.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT max-instances (#PCDATA)>
+<!-- PCDATA value: a numeric value (positive integer) -->
+----
+
+[[max-recipients]]
+===== max-recipients XML Element
+
+Name:: max-recipients
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: The maximum number of recipients allowed for a scheduling message.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT max-recipients (#PCDATA)>
+<!-- PCDATA value: a numeric value (positive integer) -->
+----
+
+===== administrator XML Element
+
+Name:: administrator
+Namespace:: urn:ietf:params:xml:ns:ischedule
+Purpose:: Provides contact information for the administrator of the iSchedule
+Receiver.
+Definition::
++
+[source%unnumbered,xml]
+----
+<!ELEMENT administrator (#PCDATA)>
+<!-- PCDATA value: URI to contact administrator -->
+----

--- a/sources/sections/10-xml-elements.adoc
+++ b/sources/sections/10-xml-elements.adoc
@@ -5,9 +5,13 @@
 === schedule-response XML Element
 
 Name:: schedule-response
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Contains the set of responses for a POST method request.
+
 Description:: See <<schedule-response>>.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -19,9 +23,13 @@ Definition::
 ==== response XML Element
 
 Name:: response
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Contains a single response for a POST method request.
+
 Description:: See <<schedule-response>>.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -37,9 +45,14 @@ Definition::
 ===== recipient XML Element
 
 Name:: recipient
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
-Purpose:: The calendar user address (recipient header value) that the enclosing response for a POST method request is for.
+
+Purpose:: The calendar user address (recipient header value) that the enclosing
+response for a POST method request is for.
+
 Description:: See <<schedule-response>>.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -51,9 +64,13 @@ Definition::
 ===== request-status XML Element
 
 Name:: request-status
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: The iTIP REQUEST-STATUS property value for this response.
+
 Description:: See <<schedule-response>>.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -64,9 +81,14 @@ Definition::
 ===== calendar-data XML Element
 
 Name:: calendar-data
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
-Purpose:: An iCalendar object in a response to a search for busy time information.
+
+Purpose:: An iCalendar object in a response to a search for busy time
+information.
+
 Description:: See <<schedule-response>>.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -81,9 +103,14 @@ Definition::
 ===== error XML Element
 
 Name:: error
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
-Purpose:: Error responses sometimes need more information to indicate what went wrong.
+
+Purpose:: Error responses sometimes need more information to indicate what went
+wrong.
+
 Description:: See <<schedule-response>>.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -94,9 +121,13 @@ Definition::
 ===== response-description XML Element
 
 Name:: response-description
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Contains information about a status response
+
 Description:: See <<schedule-response>>.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -107,9 +138,14 @@ Definition::
 === query-result XML Element
 
 Name:: query-result
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Contains result of a query request.
-Description:: A generic container for the result of a query request, such as a query of the capabilities of an iSchedule Receiver.
+
+Description:: A generic container for the result of a query request, such as a
+query of the capabilities of an iSchedule Receiver.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -120,9 +156,14 @@ Definition::
 ==== capabilities XML Element
 
 Name:: capabilities
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Contains iSchedule Receiver capabilities.
-Description:: The capabilities element contains capabilities of the iSchedule Receiver.
+
+Description:: The capabilities element contains capabilities of the iSchedule
+Receiver.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -146,17 +187,21 @@ Definition::
 ===== serial-number XML Element
 
 Name:: serial-number
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies the version of the capabilities information.
+
 Description:: This is a numeric value maintained by the iSchedule Receiver. The
 value is incremented by the iSchedule Receiver each time there has been a
 substantive change to the capabilities that would require an iSchedule Sender to
-reload the capabilities to adjust its behavior. The value of this element MUST be
-returned by the iSchedule Receiver in all HTTP requests via the
+reload the capabilities to adjust its behavior. The value of this element MUST
+be returned by the iSchedule Receiver in all HTTP requests via the
 <<ischedule-capabilities.header,"iSchedule-Capabilities" response header>>. This
-allows iSchedule Senders to detect changes to the iSchedule Receiver's capabilities
-during the normal course of making requests, without the need to poll the iSchedule
-Receiver for such changes.
+allows iSchedule Senders to detect changes to the iSchedule Receiver's
+capabilities during the normal course of making requests, without the need to
+poll the iSchedule Receiver for such changes.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -168,11 +213,15 @@ Definition::
 ===== versions XML Element
 
 Name:: versions
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies the iSchedule versions supported by the iSchedule Receiver.
-Description:: An iSchedule Receiver MAY advertise support for multiple versions of
-the iSchedule protocol. iSchedule Senders check this value to ensure they can send
-iSchedule messages with a matching version.
+
+Description:: An iSchedule Receiver MAY advertise support for multiple versions
+of the iSchedule protocol. iSchedule Senders check this value to ensure they can
+send iSchedule messages with a matching version.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -183,8 +232,11 @@ Definition::
 ====== version XML Element
 
 Name:: version
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies an iSchedule protocol version.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -196,11 +248,15 @@ Definition::
 ===== scheduling-messages XML Element
 
 Name:: scheduling-messages
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies the type of supported scheduling messages.
-Description:: An iSchedule Receiver advertises which iCalendar component types it
-will accept for iTIP messages sent to it. In addition, for each component, it can
-specify the allowed iTIP "METHOD" property values.
+
+Description:: An iSchedule Receiver advertises which iCalendar component types
+it will accept for iTIP messages sent to it. In addition, for each component, it
+can specify the allowed iTIP "METHOD" property values.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -211,13 +267,17 @@ Definition::
 ====== component XML Element
 
 Name:: component
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies a calendar component type.
-Description:: Used to specify a supported iCalendar component type for scheduling
-messages. If a IS:method child element is not present, then any iTIP "METHOD"
-property value can be used in iTIP messages sent to the iSchedule Receiver. If one
-or more IS:method elements are present, then those indicate the allowed set of iTIP
-"METHOD" property values.
+
+Description:: Used to specify a supported iCalendar component type for
+scheduling messages. If a IS:method child element is not present, then any iTIP
+"METHOD" property value can be used in iTIP messages sent to the iSchedule
+Receiver. If one or more IS:method elements are present, then those indicate the
+allowed set of iTIP "METHOD" property values.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -232,9 +292,13 @@ Definition::
 ====== method XML Element
 
 Name:: method
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies an iCalendar method type.
+
 Description:: See IS:component.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -248,8 +312,11 @@ Definition::
 ===== calendar-data-types XML Element
 
 Name:: calendar-data-types
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies what formats of iCalendar data are acceptable.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -260,8 +327,11 @@ Definition::
 ====== calendar-data-type XML Element
 
 Name:: calendar-data-type
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies a supported media type and version for iTIP messages.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -277,15 +347,19 @@ Definition::
 ===== attachments XML Element
 
 Name:: attachments
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies the attachment values supported.
+
 Description:: iSchedule Receivers might restrict what form of attachments are
-allowed in iTIP messages that are sent to it, for performance, or security reasons.
-In iCalendar data, attachments can either be specified using "inline" data in the
-form of a base64 encoded property value, or "external" data in the form of a URI
-property value. With this capability, an iSchedule Receiver can specify which of
-"inline" or "external" values it will accept in iTIP messages. See
-<<security_attachments>> for additional details.
+allowed in iTIP messages that are sent to it, for performance, or security
+reasons. In iCalendar data, attachments can either be specified using "inline"
+data in the form of a base64 encoded property value, or "external" data in the
+form of a URI property value. With this capability, an iSchedule Receiver can
+specify which of "inline" or "external" values it will accept in iTIP messages.
+See <<security_attachments>> for additional details.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -296,8 +370,11 @@ Definition::
 ====== inline XML Element
 
 Name:: inline
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies "inline" attachments as a supported attachment value.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -308,8 +385,11 @@ Definition::
 ====== external XML Element
 
 Name:: external
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies "external" attachments as a supported attachment value.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -320,11 +400,15 @@ Definition::
 ===== rscales XML Element
 
 Name:: rscales
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Identifies the "RSCALE" values supported.
-Description:: iSchedule Receivers might support the <<RFC7529,iCalendar "RSCALE">>
-element on the "RRULE" property. The iSchedule Receiver can advertise what "RSCALE"
-values are supported via the IS:rscales element.
+
+Description:: iSchedule Receivers might support the <<RFC7529,iCalendar
+"RSCALE">> element on the "RRULE" property. The iSchedule Receiver can advertise
+what "RSCALE" values are supported via the IS:rscales element.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -335,8 +419,11 @@ Definition::
 ====== rscale XML Element
 
 Name:: rscale
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Indicates a supported "RSCALE" value.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -347,8 +434,12 @@ Definition::
 ===== max-content-length XML Element
 
 Name:: max-content-length
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
-Purpose:: Identifies the maximum size allowed for a scheduling message in octets.
+
+Purpose:: Identifies the maximum size allowed for a scheduling message in
+octets.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -360,10 +451,13 @@ Definition::
 ===== min-date-time XML Element
 
 Name:: min-date-time
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
-Purpose:: A DATE-TIME value indicating the earliest date and time in UTC that the
-iSchedule Receiver is willing to accept for any DATE or DATE-TIME value in a
+
+Purpose:: A DATE-TIME value indicating the earliest date and time in UTC that
+the iSchedule Receiver is willing to accept for any DATE or DATE-TIME value in a
 scheduling message.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -375,10 +469,13 @@ Definition::
 ===== max-date-time XML Element
 
 Name:: max-date-time
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: A DATE-TIME value indicating the latest date and time in UTC that the
 iSchedule Receiver is willing to accept for any DATE or DATE-TIME value in a
 scheduling message.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -390,8 +487,12 @@ Definition::
 ===== max-instances XML Element
 
 Name:: max-instances
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
-Purpose:: The maximum number of recurrence instances allowed in a scheduling message.
+
+Purpose:: The maximum number of recurrence instances allowed in a scheduling
+message.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -404,8 +505,11 @@ Definition::
 ===== max-recipients XML Element
 
 Name:: max-recipients
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: The maximum number of recipients allowed for a scheduling message.
+
 Definition::
 +
 [source%unnumbered,xml]
@@ -417,9 +521,12 @@ Definition::
 ===== administrator XML Element
 
 Name:: administrator
+
 Namespace:: urn:ietf:params:xml:ns:ischedule
+
 Purpose:: Provides contact information for the administrator of the iSchedule
 Receiver.
+
 Definition::
 +
 [source%unnumbered,xml]

--- a/sources/sections/11-security.adoc
+++ b/sources/sections/11-security.adoc
@@ -1,0 +1,34 @@
+[[security]]
+== Security Considerations
+
+The process of scheduling involves the sending and receiving of scheduling messages.
+As a result, the security problems related to messaging in general are relevant
+here. In particular the authenticity of the scheduling messages needs to be verified.
+
+=== Privacy
+
+iSchedule Senders and iSchedule Receivers MUST use an HTTP connection protected with
+TLS <<RFC5246>> as defined in <<RFC2818>> for all transactions.
+
+=== Authentication
+
+=== DNS Considerations
+
+DNS security issues are addressed by DNSSEC <<RFC4033>>.
+
+[[security_attachments]]
+=== Attachment Considerations
+
+iCalendar data can include "inline" attachment data in the form of a base64-encoded
+"ATTACH" property value. iSchedule Receivers MUST take care when allowing "inline"
+attachments in scheduling messages as such data might contain malicious content, and
+SHOULD use some form of content scanner on the attachment data to verify its safety
+(e.g., a content scanner used for email messages). In addition, "inline" attachment
+data is likely to be much larger than the actual calendar-related data in a
+scheduling message, and thus could adversely affect the performance of an iSchedule
+Receiver processing it. If an iSchedule Receiver allows "inline" attachment data, it
+MUST apply a limit on the size of acceptable scheduling messages to prevent possible
+denial-of-service attacks using large "inline" attachment data. In general, it is
+best for iSchedule Receivers to simply disable the ability for scheduling messages
+to contain "inline" attachment data, and instead rely solely on "external"
+attachments in the form of URI attachment values.

--- a/sources/sections/11-security.adoc
+++ b/sources/sections/11-security.adoc
@@ -1,14 +1,15 @@
 [[security]]
 == Security Considerations
 
-The process of scheduling involves the sending and receiving of scheduling messages.
-As a result, the security problems related to messaging in general are relevant
-here. In particular the authenticity of the scheduling messages needs to be verified.
+The process of scheduling involves the sending and receiving of scheduling
+messages. As a result, the security problems related to messaging in general are
+relevant here. In particular the authenticity of the scheduling messages needs
+to be verified.
 
 === Privacy
 
-iSchedule Senders and iSchedule Receivers MUST use an HTTP connection protected with
-TLS <<RFC5246>> as defined in <<RFC2818>> for all transactions.
+iSchedule Senders and iSchedule Receivers MUST use an HTTP connection protected
+with TLS <<RFC5246>> as defined in <<RFC2818>> for all transactions.
 
 === Authentication
 
@@ -19,16 +20,17 @@ DNS security issues are addressed by DNSSEC <<RFC4033>>.
 [[security_attachments]]
 === Attachment Considerations
 
-iCalendar data can include "inline" attachment data in the form of a base64-encoded
-"ATTACH" property value. iSchedule Receivers MUST take care when allowing "inline"
-attachments in scheduling messages as such data might contain malicious content, and
-SHOULD use some form of content scanner on the attachment data to verify its safety
-(e.g., a content scanner used for email messages). In addition, "inline" attachment
-data is likely to be much larger than the actual calendar-related data in a
-scheduling message, and thus could adversely affect the performance of an iSchedule
-Receiver processing it. If an iSchedule Receiver allows "inline" attachment data, it
-MUST apply a limit on the size of acceptable scheduling messages to prevent possible
-denial-of-service attacks using large "inline" attachment data. In general, it is
-best for iSchedule Receivers to simply disable the ability for scheduling messages
-to contain "inline" attachment data, and instead rely solely on "external"
-attachments in the form of URI attachment values.
+iCalendar data can include "inline" attachment data in the form of a
+base64-encoded "ATTACH" property value. iSchedule Receivers MUST take care when
+allowing "inline" attachments in scheduling messages as such data might contain
+malicious content, and SHOULD use some form of content scanner on the attachment
+data to verify its safety (e.g., a content scanner used for email messages). In
+addition, "inline" attachment data is likely to be much larger than the actual
+calendar-related data in a scheduling message, and thus could adversely affect
+the performance of an iSchedule Receiver processing it. If an iSchedule Receiver
+allows "inline" attachment data, it MUST apply a limit on the size of acceptable
+scheduling messages to prevent possible denial-of-service attacks using large
+"inline" attachment data. In general, it is best for iSchedule Receivers to
+simply disable the ability for scheduling messages to contain "inline"
+attachment data, and instead rely solely on "external" attachments in the form
+of URI attachment values.

--- a/sources/sections/12-iana.adoc
+++ b/sources/sections/12-iana.adoc
@@ -1,0 +1,86 @@
+[[IANA]]
+== IANA Considerations
+
+[[IANA_NS]]
+=== Namespace Registration
+
+This specification registers a new URN to identify a new XML namespace as per
+<<RFC3688>>.
+
+[[IANA_NS_ISCHEDULE]]
+==== iSchedule Namespace Registration
+
+Registration request for the iSchedule namespace:
+
+URI:: urn:ietf:params:xml:ns:ischedule
+
+Registrant Contact:: See the "Authors' Addresses" section of this document.
+
+XML:: None. Namespace URIs do not represent an XML specification.
+
+[[IANA_HTTP]]
+=== HTTP Headers Registration
+
+This specification registers new headers for use with HTTP as per <<RFC3864>>.
+
+[[IANA_HTTP_ISCHEDULE_VERSION]]
+==== iSchedule-Version General Header Registration
+
+Header field name:: iSchedule-Version
+Applicable protocol:: http
+Status:: standard
+Author/Change controller:: IETF
+Specification document(s):: this specification
+Related information:: none
+
+[[IANA_HTTP_ISCHEDULE_CAPABILITIES]]
+==== iSchedule-Capabilities Response Header Registration
+
+Header field name:: iSchedule-Capabilities
+Applicable protocol:: http
+Status:: standard
+Author/Change controller:: IETF
+Specification document(s):: this specification
+Related information:: none
+
+[[IANA_HTTP_ISCHEDULE_MESSAGE_ID]]
+==== iSchedule-Message-ID Request Header Registration
+
+Header field name:: iSchedule-Message-ID
+Applicable protocol:: http
+Status:: standard
+Author/Change controller:: IETF
+Specification document(s):: this specification
+Related information:: none
+
+[[IANA_HTTP_ORIGINATOR]]
+==== Originator Request Header Registration
+
+Header field name:: Originator
+Applicable protocol:: http
+Status:: standard
+Author/Change controller:: IETF
+Specification document(s):: this specification
+Related information:: none
+
+[[IANA_HTTP_RECIPIENT]]
+==== Recipient Request Header Registration
+
+Header field name:: Recipient
+Applicable protocol:: http
+Status:: standard
+Author/Change controller:: IETF
+Specification document(s):: this specification
+Related information:: none
+
+=== Well-Known URI Registration
+
+This specification registers a new well-known URI as per <<RFC5785>>.
+
+[[IANA.WELL-KNOWN-URI]]
+==== iSchedule Well-Known URI Registration
+
+URI suffix:: ischedule
+Change controller:: IETF.
+Specification document(s):: this specification
+Related information:: none

--- a/sources/sections/99-acknowledgements.adoc
+++ b/sources/sections/99-acknowledgements.adoc
@@ -1,0 +1,19 @@
+[acknowledgments]
+== Acknowledgments
+
+The authors would like to thank the following individuals for contributing their ideas
+and support for writing this specification:
+Mattias Amnefelt,
+Mike Douglass,
+Tomas Hnetila,
+Ciny Joy,
+Barry Leiba,
+Ken Murchison,
+Simon Pilette,
+Arnaud Quillaud,
+Simon Vaillancourt, and
+Wilfredo Sanchez Vega.
+
+The authors would also like to thank CalConnect, The Calendaring and Scheduling
+Consortium, for advice with this specification, and for organizing interoperability
+testing events to help refine it.

--- a/sources/sections/99-bibliography.adoc
+++ b/sources/sections/99-bibliography.adoc
@@ -1,0 +1,8 @@
+[bibliography]
+== Bibliography
+
+* [[[RFC3864,IETF RFC 3864]]]
+* [[[RFC4791,IETF RFC 4791]]]
+* [[[RFC6047,IETF RFC 6047]]]
+* [[[RFC6638,IETF RFC 6638]]]
+* [[[RFC7529,IETF RFC 7529]]]

--- a/sources/sections/aa-examples.adoc
+++ b/sources/sections/aa-examples.adoc
@@ -2,21 +2,21 @@
 [appendix]
 == Example Scheduling Transactions
 
-This section describes some example scheduling transactions that give a general idea
-of how scheduling is carried out between an iSchedule Sender and an iSchedule
-Receiver.
+This section describes some example scheduling transactions that give a general
+idea of how scheduling is carried out between an iSchedule Sender and an
+iSchedule Receiver.
 
 [[schedule-example]]
 === Example: Simple Meeting Invitation
 
-In the following example, the iSchedule Sender requests the iSchedule Receiver to
-deliver a meeting invitation (scheduling REQUEST) to the calendar user
+In the following example, the iSchedule Sender requests the iSchedule Receiver
+to deliver a meeting invitation (scheduling REQUEST) to the calendar user
 mailto:cyrus@example.org. The response indicates that delivery of the scheduling
 message was successful.
 
-.>> Request <<
 [source%unnumbered]
 ----
+>> Request <<
 POST /.well-known/ischedule HTTP/1.1
 Host: cal.example.org
 iSchedule-Version: 1.0
@@ -48,9 +48,9 @@ END:VEVENT
 END:VCALENDAR
 ----
 
-.>> Response <<
 [source%unnumbered]
 ----
+>> Response <<
 HTTP/1.1 200 OK
 Date: Thu, 02 Sep 2004 16:53:32 GMT
 Content-Type: application/xml; charset=utf-8
@@ -78,9 +78,9 @@ mailto:mike@example.org, over the time range specified by the scheduling message
 sent in the request. The response includes VFREEBUSY components with the busy time
 for one calendar user, and an error for the other calendar user.
 
-.>> Request <<
 [source%unnumbered]
 ----
+>> Request <<
 POST /.well-known/ischedule HTTP/1.1
 Host: cal.example.org
 iSchedule-Version: 1.0
@@ -108,9 +108,9 @@ END:VFREEBUSY
 END:VCALENDAR
 ----
 
-.>> Response <<
 [source%unnumbered]
 ----
+>> Response <<
 HTTP/1.1 200 OK
 Date: Thu, 02 Sep 2004 16:53:32 GMT
 Content-Type: application/xml; charset=utf-8
@@ -158,9 +158,9 @@ deliver a task assignment (scheduling REQUEST) to the calendar user
 mailto:cyrus@example.org. For some reason the verification of the request fails as
 is indicated by the error response.
 
-.>> Request <<
 [source%unnumbered]
 ----
+>> Request <<
 POST /.well-known/ischedule HTTP/1.1
 Host: cal.example.org
 iSchedule-Version: 1.0
@@ -187,9 +187,9 @@ END:VEVENT
 END:VCALENDAR
 ----
 
-.>> Response <<
 [source%unnumbered]
 ----
+>> Response <<
 HTTP/1.1 403 FORBIDDEN
 Date: Thu, 02 Sep 2004 16:53:32 GMT
 Content-Type: application/xml; charset=utf-8

--- a/sources/sections/aa-examples.adoc
+++ b/sources/sections/aa-examples.adoc
@@ -1,0 +1,205 @@
+[[examples]]
+[appendix]
+== Example Scheduling Transactions
+
+This section describes some example scheduling transactions that give a general idea
+of how scheduling is carried out between an iSchedule Sender and an iSchedule
+Receiver.
+
+[[schedule-example]]
+=== Example: Simple Meeting Invitation
+
+In the following example, the iSchedule Sender requests the iSchedule Receiver to
+deliver a meeting invitation (scheduling REQUEST) to the calendar user
+mailto:cyrus@example.org. The response indicates that delivery of the scheduling
+message was successful.
+
+.>> Request <<
+[source%unnumbered]
+----
+POST /.well-known/ischedule HTTP/1.1
+Host: cal.example.org
+iSchedule-Version: 1.0
+iSchedule-Message-ID: 798F00BB-5B45-4634-B083-0D0CD3A2BB39
+Originator: mailto:bernard@example.com
+Recipient: mailto:cyrus@example.org
+Cache-Control: no-cache, no-transform
+Content-Type: text/calendar; component=VEVENT; method=REQUEST
+Content-Length: xxxx
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Example Corp.//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+DTSTAMP:20040901T200200Z
+ORGANIZER:mailto:bernard@example.com
+DTSTART:20040902T130000Z
+DTEND:20040902T140000Z
+SUMMARY:Design meeting
+UID:34222-232@example.com
+ATTENDEE;PARTSTAT=ACCEPTED;ROLE=CHAIR;CUTYPE=IND
+ IVIDUAL;CN=Bernard Desruisseaux:mailto:bernard@
+ example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=RE
+ Q-PARTICIPANT;CUTYPE=INDIVIDUAL;CN=Cyrus Daboo:
+ mailto:cyrus@example.org
+END:VEVENT
+END:VCALENDAR
+----
+
+.>> Response <<
+[source%unnumbered]
+----
+HTTP/1.1 200 OK
+Date: Thu, 02 Sep 2004 16:53:32 GMT
+Content-Type: application/xml; charset=utf-8
+Content-Length: xxxx
+Cache-Control: no-cache, no-transform
+iSchedule-Version: 1.0
+iSchedule-Capabilities: 123
+
+<?xml version="1.0" encoding="utf-8" ?>
+<schedule-response xmlns="urn:ietf:params:xml:ns:ischedule">
+  <response>
+    <recipient>mailto:cyrus@example.org</recipient>
+    <request-status>2.0;Success</request-status>
+    <response-description>Delivered to recipient</response-description>
+  </response>
+</schedule-response>
+----
+
+[[schedule-fb-example]]
+=== Example: Search for Busy Time Information
+
+In the following example, the iSchedule Sender requests the iSchedule Receiver to
+determine the busy information of the calendar users mailto:cyrus@example.org and
+mailto:mike@example.org, over the time range specified by the scheduling message
+sent in the request. The response includes VFREEBUSY components with the busy time
+for one calendar user, and an error for the other calendar user.
+
+.>> Request <<
+[source%unnumbered]
+----
+POST /.well-known/ischedule HTTP/1.1
+Host: cal.example.org
+iSchedule-Version: 1.0
+iSchedule-Message-ID: A98ADF24-9490-4F01-81C8-FE924F86A9FD
+Originator: mailto:bernard@example.com
+Recipient: mailto:cyrus@example.org
+Recipient: mailto:mike@example.org
+Cache-Control: no-cache, no-transform
+Content-Type: text/calendar; component=VFREEBUSY; method=REQUEST
+Content-Length: xxxx
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Example Corp.//EN
+METHOD:REQUEST
+BEGIN:VFREEBUSY
+DTSTAMP:20040901T200200Z
+ORGANIZER:mailto:bernard@example.com
+DTSTART:20040902T000000Z
+DTEND:20040903T000000Z
+UID:34222-232@example.com
+ATTENDEE;CN=Cyrus Daboo:mailto:cyrus@example.org
+ATTENDEE;CN=Mike Douglass:mailto:mike@example.org
+END:VFREEBUSY
+END:VCALENDAR
+----
+
+.>> Response <<
+[source%unnumbered]
+----
+HTTP/1.1 200 OK
+Date: Thu, 02 Sep 2004 16:53:32 GMT
+Content-Type: application/xml; charset=utf-8
+Content-Length: xxxx
+Cache-Control: no-cache, no-transform
+iSchedule-Version: 1.0
+iSchedule-Capabilities: 123
+
+<?xml version="1.0" encoding="utf-8" ?>
+<schedule-response xmlns="urn:ietf:params:xml:ns:ischedule">
+  <response>
+    <recipient>mailto:cyrus@example.org</recipient>
+    <request-status>2.0;Success</request-status>
+    <calendar-data>BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Example Corp.//EN
+METHOD:REPLY
+BEGIN:VFREEBUSY
+DTSTAMP:20040901T200200Z
+ORGANIZER:mailto:bernard@example.com
+DTSTART:20040902T000000Z
+DTEND:20040903T000000Z
+UID:34222-232@example.com
+ATTENDEE;CN=Cyrus Daboo:mailto:cyrus@example.org
+FREEBUSY;FBTYPE=BUSY-UNAVAILABLE:20040902T000000Z/
+ 20040902T090000Z,20040902T170000Z/20040903T000000Z
+FREEBUSY;FBTYPE=BUSY:20040902T120000Z/20040902T130000Z
+END:VFREEBUSY
+END:VCALENDAR
+    </calendar-data>
+  </response>
+  <response>
+    <recipient>mailto:mike@example.org</recipient>
+    <request-status>5.3;No scheduling support for user</request-status>
+    <response-description>Unknown calendar user</response-description>
+  </response>
+</schedule-response>
+----
+
+[[schedule-example-task]]
+=== Example: Failed Request
+
+In the following example, the iSchedule Sender requests the iSchedule Sender to
+deliver a task assignment (scheduling REQUEST) to the calendar user
+mailto:cyrus@example.org. For some reason the verification of the request fails as
+is indicated by the error response.
+
+.>> Request <<
+[source%unnumbered]
+----
+POST /.well-known/ischedule HTTP/1.1
+Host: cal.example.org
+iSchedule-Version: 1.0
+Originator: mailto:bernard@example.com
+Recipient: mailto:cyrus@example.org
+Cache-Control: no-cache, no-transform
+Content-Type: text/calendar; component=VTODO; method=REQUEST
+Content-Length: xxxx
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Example Corp.//CalDAV Client//EN
+METHOD:REQUEST
+BEGIN:VTODO
+DTSTAMP:20040901T200200Z
+ORGANIZER:mailto:bernard@example.com
+DUE:20070505
+SUMMARY:Review Internet-Draft
+UID:34222-456@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=RE
+ Q-PARTICIPANT;CUTYPE=INDIVIDUAL;CN=Cyrus Daboo:
+ mailto:cyrus@example.org
+END:VEVENT
+END:VCALENDAR
+----
+
+.>> Response <<
+[source%unnumbered]
+----
+HTTP/1.1 403 FORBIDDEN
+Date: Thu, 02 Sep 2004 16:53:32 GMT
+Content-Type: application/xml; charset=utf-8
+Content-Length: xxxx
+iSchedule-Version: 1.0
+iSchedule-Capabilities: 123
+
+<?xml version="1.0" encoding="utf-8" ?>
+<error xmlns="urn:ietf:params:xml:ns:ischedule">
+  <verification-failed />
+  <response-description>Unable to verify request</response-description>
+</error>
+----


### PR DESCRIPTION
Closes #2 .

Notes:
* Date was not given initially, so it needs to be changed in the main adoc.
* The Introduction section contains multiple subsections usually represented by Conventions and Terms and Definitions sections. In this case, the original structure remains unchanged. Please let me know if any adjustments are needed.